### PR TITLE
[PBW-4067] Bitmovin plugin doesn't update current time after seeking

### DIFF
--- a/src/bit/js/bit_wrapper.js
+++ b/src/bit/js/bit_wrapper.js
@@ -278,6 +278,7 @@ require("../../../html5-common/js/utils/environment.js");
     var resetStreamData = _.bind(function() {
       _hasPlayed = false;
       _videoEnded = false;
+      _wasSeeking = false;
     }, this);
 
     /**


### PR DESCRIPTION
Bitmovin plugin gets seek event when seek is over, so it should both update VTC with new playhead time and then send SEEKED event
