### PR TITLE
[PBF-446] Fix for media stream error when volume is changed

### DIFF
--- a/src/osmf/js/osmf_flash.js
+++ b/src/osmf/js/osmf_flash.js
@@ -465,7 +465,7 @@
     };
 
     var raiseVolumeEvent = function(event) {
-      newController.notify(newController.EVENTS.VOLUME_CHANGE, { "volume" : event.target.volume });
+      newController.notify(newController.EVENTS.VOLUME_CHANGE, { "volume" : event.eventObject.volume });
     };
 
     var raiseWaitingEvent = function() {
@@ -595,7 +595,7 @@
        case "STALLED":
         raiseStalledEvent();
         break;
-       case "VOLUME_CHANGE":
+       case "VOLUME_CHANGED":
         raiseVolumeEvent(data);
         break;
        case "WAITING":


### PR DESCRIPTION
When volume is changed, VOLUME_CHANGED  event is dispatched from action
script. Hence changed the event name to “VOLUME_CHANGED”
