### PR TITLE
[PBF-449] Flash not destroying old video on next video

### DIFF
--- a/src/osmf/js/osmf_flash.js
+++ b/src/osmf/js/osmf_flash.js
@@ -375,7 +375,7 @@
       this.pause();
 
       // Reset the source
-      this.setVideoUrl = "";
+      this.setVideoUrl('');
 
       // Unsubscribe all events
       this.unsubscribeAllEvents();


### PR DESCRIPTION
Two copies of the “object” tag were remaining in the HTML. VTC was
communicating with the proper new one, but the old one’s background
color was obscuring the video of the new one. Added code to properly
unsubscribe and then delete the old old object tag.
