### PR TITLE
[PBF-439] wmode to opaque

### DIFF
--- a/src/osmf/js/osmf_flash.js
+++ b/src/osmf/js/osmf_flash.js
@@ -168,7 +168,7 @@
     params.bgcolor = "#000000";
     params.allowscriptaccess = "always";
     params.allowfullscreen = "true";
-    params.wmode = "direct";
+    params.wmode = "opaque";
 
     var attributes = {};
     attributes.id = playerId;


### PR DESCRIPTION
We need to set wmode to opaque to get the html5 to layer above it due
to the position absolulte of the player_skin div. Alternatively we
could change player_skin to not be position absolute - but this could
have unpredictable results on unknown end user layouts.
