### PR TITLE
[PBF-454] Overlay ads not displaying

### DIFF
--- a/src/osmf/js/osmf_flash.js
+++ b/src/osmf/js/osmf_flash.js
@@ -178,8 +178,7 @@
     attributes.id = playerId;
     attributes.class = 'video';
     attributes.preload = 'none';
-    attributes.style = '';
-
+    attributes.style = 'position:absolute;';
     // Combine the css object into a string for swfobject.
     if (cssFromContainer.length) {
       for(i in cssFromContainer) {


### PR DESCRIPTION
Sets a default style position for overlay ads that lack their own css
position tag.
