### PR TITLE
[PBF-483] Fix for supporting HTTPS steam in OSMF player

### DIFF
--- a/src/osmf/lib/HDSPlayer.as
+++ b/src/osmf/lib/HDSPlayer.as
@@ -80,6 +80,8 @@ package
     public function HDSPlayer( )
     {
       Security.allowDomain("*");
+      Security.allowInsecureDomain('*')
+
       var externalJavaScriptApi:ExternalJavaScriptAPI = new ExternalJavaScriptAPI(this);
     }
     


### PR DESCRIPTION
The code to allow insecure domain has been added as http page (i.e http://debug.ooyala.com)  embeds and tries to access secure https swf. The code has been added to allow all insecure domains as the player will be hosted on multiple customer's website which will be on separate domains. 