### PR TITLE
Change for-in loop to a normal for

### DIFF
--- a/src/osmf/js/osmf_flash.js
+++ b/src/osmf/js/osmf_flash.js
@@ -18,8 +18,8 @@ require("../../../html5-common/js/utils/constants.js");
   var pluginPath;
   var filename = "osmf_flash.*\.js";
   var scripts = document.getElementsByTagName('script');
-  for (var index in scripts) {
-    var match = scripts[index].src.match(filename);
+  for (var i = 0; i < scripts.length; i++) {
+    var match = scripts[i].src.match(filename);
     if (match && match.length > 0) {
       pluginPath = match.input.match(/.*\//)[0];
       break;

--- a/src/osmf/js/osmf_flash.js
+++ b/src/osmf/js/osmf_flash.js
@@ -261,7 +261,7 @@ require("../../../html5-common/js/utils/constants.js");
      * @public
      * @method OoyalaFlashVideoWrapper#setVideoUrl
      * @param {string} url The new url to insert into the video element's src attribute
-     * @param {string} encoding The encoding of video stream 
+     * @param {string} encoding The encoding of video stream
      * @returns {boolean} True or false indicating success
      */
     this.setVideoUrl = function(url, encoding) {
@@ -309,7 +309,7 @@ require("../../../html5-common/js/utils/constants.js");
      * Sets the closed captions mode of the video playback.
      * @public
      * @method OoyalaFlashVideoWrapper#setClosedCaptionsMode
-     * @param {string} mode Mode of the captions(disabled/showing) 
+     * @param {string} mode Mode of the captions(disabled/showing)
      */
 
     this.setClosedCaptionsMode = function(mode){
@@ -438,7 +438,7 @@ require("../../../html5-common/js/utils/constants.js");
       this.setVideoUrl('');
 
       // Unsubscribe all events
-      
+
       this.unsubscribeAllEvents();
 
       // Pass destroy to flash plugin.
@@ -592,7 +592,7 @@ require("../../../html5-common/js/utils/constants.js");
       newController.notify(newControllerr.EVENTS.FULLSCREEN_CHANGED,
                              { "isFullScreen" : false, "paused" : event.target.paused });
     };
-  
+
     var raiseBitrateChanged = function(event) {
       var vtcBitrate = {
           id: event.eventObject.id,


### PR DESCRIPTION
[`getElementsByTagName`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getElementsByTagName) returns an array-like object that is better traversed using a regular for loop, rather than a for-in one. This eliminates some weird errors for properties trying to be accessed in the for-in loop, such as `length`.

I honestly couldn't get the tests running, could someone please run them locally before merging?