### PR TITLE
[PBF-639][Flash] Live stream scrubber pointer is displayed at initial point

### DIFF
--- a/src/osmf/lib/HDSPlayer.as
+++ b/src/osmf/lib/HDSPlayer.as
@@ -750,7 +750,7 @@ package
         totalTime = 0;
       }
       eventObject.currentTime = _mediaPlayerSprite.mediaPlayer.currentTime;
-      eventObject.duration = duration
+      eventObject.duration = totalTime;
       eventObject.buffer = _mediaPlayerSprite.mediaPlayer.bufferLength + _mediaPlayerSprite.mediaPlayer.currentTime;
       eventObject.seekRange_start = 0;
       eventObject.seekRange_end = totalTime;


### PR DESCRIPTION
Event object's duration should be set to totalTime, which is zero in case of non-seakable (live) media.  Skin expects zero duration for non-seekable media.