### PR TITLE
[fix-osmf-build] Dele auto-generated library before compile starts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ npm-debug.log
 build/*
 coverage/*
 docs/*
+link_report.xml
+src/osmf/lib/closedCaption.swc

--- a/build_flash.xml
+++ b/build_flash.xml
@@ -23,6 +23,9 @@
  
   <!-- Build closed caption swc -->
   <target name="build-CCswc">
+    <delete>
+      <fileset file="${basedir}/src/osmf/lib/closedCaption.swc" />
+    </delete>
     <compc output="${basedir}/src/osmf/lib/closedCaption.swc" >
       <source-path path-element="${basedir}/utils/ClosedCaption/"/>
         <include-sources dir="${basedir}/utils/ClosedCaption/" includes="*.as"/>


### PR DESCRIPTION
Delete auto-generated library before compile starts, otherwise link error of multple class definition will happen if this library is present from previous build