### PR TITLE
[PBW-4457] CC button always showing in Safari

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -681,7 +681,7 @@ require("../../../html5-common/js/utils/environment.js");
       if (_video.textTracks && _video.textTracks.length > 0) {
         var languages = [];
         for (var i = 0; i < _video.textTracks.length; i++) {
-          if (_video.textTracks[i].kind === "captions") {
+          if (_video.textTracks[i].kind === "captions" && !_video.textTracks[i].src === "undefined") {
             var captionInfo = {
               language: "CC",
               inStream: true,


### PR DESCRIPTION
Adds a condition to check if the textTrack for the video element has a
src associated with it.