### PR TITLE
Revert "[PBW-4457] CC button always showing in Safari"

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -681,7 +681,7 @@ require("../../../html5-common/js/utils/environment.js");
       if (_video.textTracks && _video.textTracks.length > 0) {
         var languages = [];
         for (var i = 0; i < _video.textTracks.length; i++) {
-          if (_video.textTracks[i].kind === "captions" && !_video.textTracks[i].src === "undefined") {
+          if (_video.textTracks[i].kind === "captions") {
             var captionInfo = {
               language: "CC",
               inStream: true,


### PR DESCRIPTION
This reverts commit bfc1c6ef3718b25cd4f21a9d0350c759fa3a8798.
It is not a correct way to check for undefined.  Should be either 'a != undefined', or, better 'typeof a != "undefined"'