### PR TITLE
[PBW-4479] Prevent notification of pause event on iPad at time 0 to p…

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -984,8 +984,9 @@ require("../../../html5-common/js/utils/environment.js");
       if (isPriming) {
         return;
       }
-
-      this.controller.notify(this.controller.EVENTS.PAUSED);
+      if (!(OO.isIpad && _video.currentTime === 0)) {
+        this.controller.notify(this.controller.EVENTS.PAUSED);
+      }
       forceEndOnPausedIfRequired();
     }, this);
 


### PR DESCRIPTION
Prevent notification of pause event on iPad at time 0 to prevent flashing of discovery screen.
We still do the pause, because of the "raiseStalledEvent" fix for "multiple video tag errors in iPad", but we keep the notification suppressed to prevent this from triggering Discovery.

