### PR TITLE
[PBW-5567] Seeking is ignored from video end screen, it always plays from the beginning

### DIFF
--- a/src/akamai/js/akamaiHD_flash.js
+++ b/src/akamai/js/akamaiHD_flash.js
@@ -324,7 +324,7 @@ require("../../../html5-common/js/utils/constants.js");
      * @param {number} initialTime The initial time of the video (seconds)
      */
     this.setInitialTime = function(initialTime) {
-      if (!hasPlayed) {
+      if (!hasPlayed || videoEnded) {
         this.seek(initialTime);
       }
     };

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -373,7 +373,7 @@ require("../../../html5-common/js/utils/environment.js");
      * @param {number} time The initial time of the video (seconds)
      */
     this.setInitialTime = function(time) {
-      if (!hasPlayed && (time !== 0)) {
+      if ((!hasPlayed || videoEnded) && (time !== 0)) {
         initialTime.value = time;
         initialTime.reached = false;
 

--- a/src/osmf/js/osmf_flash.js
+++ b/src/osmf/js/osmf_flash.js
@@ -373,7 +373,7 @@ require("../../../html5-common/js/utils/constants.js");
      * @param {number} initialTime The initial time of the video (seconds)
      */
     this.setInitialTime = function(initialTime) {
-      if (!hasPlayed) {
+      if (!hasPlayed || videoEnded) {
         this.seek(initialTime);
       }
     };

--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -219,6 +219,14 @@ describe('main_html5 wrapper tests', function () {
     expect(wrapper.seek.wasCalled).to.be(false);
   });
 
+  it('should act on initialTime if has played and video ended', function(){
+    spyOn(wrapper, "seek");
+    wrapper.play();
+    $(element).triggerHandler("ended");
+    wrapper.setInitialTime(10);
+    expect(wrapper.seek.wasCalled).to.be(true);
+  });
+
   it('should call pause on element when wrapper paused', function(){
     spyOn(wrapper, "pause");
     wrapper.pause();


### PR DESCRIPTION
* Also allow setting initial time if video has ended
* Updated unit tests