### PR TITLE
[PBW-4456] Removed duplicate videoEnded=false that was confusing replay

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -634,7 +634,6 @@ require("../../../html5-common/js/utils/environment.js");
       stopUnderflowWatcher();
       _currentUrl = _video.src;
       firstPlay = true;
-      videoEnded = false;
       isSeeking = false;
     }, this);
 


### PR DESCRIPTION
Removed duplicate videoEnded=false that was confusing player on replay. videoEnded=false remain in exeuctePlay where it belongs.
