### PR TITLE
[PBW-5865]

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -510,7 +510,11 @@ require("../../../html5-common/js/utils/environment.js");
      */
     this.destroy = function() {
       _video.pause();
-      _video.src = '';
+      //On IE and Edge, setting the video source to an empty string has the unwanted effect
+      //of a network request to the base url
+      if (!OO.isIE && !OO.isEdge) {
+        _video.src = '';
+      }
       unsubscribeAllEvents();
       $(_video).remove();
       if (_playerId && currentInstances[_playerId] && currentInstances[_playerId] > 0) {


### PR DESCRIPTION
-workaround of an IE/Edge issue where setting a video src to an empty string has the side effect of a network request to the base URL of the page