### PR TITLE
[PBW-5539] - Allowing initialTime of 0 on Safari as a workaround for browser bug

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -392,11 +392,11 @@ require("../../../html5-common/js/utils/environment.js");
      */
     this.setInitialTime = function(time) {
       var canSetInitialTime = (!hasPlayed || videoEnded) && (time !== 0);
-      // [PBW-5539] On iOS, when triggering replay after the current browser tab looses focus, the
+      // [PBW-5539] On Safari (iOS and Desktop), when triggering replay after the current browser tab looses focus, the
       // current time seems to fall a few milliseconds behind the video duration, which
       // makes the video play for a fraction of a second and then stop again at the end.
       // In this case we allow setting the initial time back to 0 as a workaround for this
-      var initialTimeRequired = OO.isIos && videoEnded && time === 0;
+      var initialTimeRequired = OO.isSafari && videoEnded && time === 0;
 
       if (canSetInitialTime || initialTimeRequired) {
         initialTime.value = time;
@@ -405,7 +405,8 @@ require("../../../html5-common/js/utils/environment.js");
         // [PBW-3866] Some Android devices (mostly Nexus) cannot be seeked too early or the seeked event is
         // never raised, even if the seekable property returns an endtime greater than the seek time.
         // To avoid this, save seeking information for use later.
-        if (OO.isAndroid) {
+        // [PBW-5539] Same issue with desktop Safari
+        if (OO.isAndroid || (OO.isSafari && !OO.isIos)) {
           queueSeek(initialTime.value);
         }
         else {

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -391,7 +391,14 @@ require("../../../html5-common/js/utils/environment.js");
      * @param {number} time The initial time of the video (seconds)
      */
     this.setInitialTime = function(time) {
-      if ((!hasPlayed || videoEnded) && (time !== 0)) {
+      var canSetInitialTime = (!hasPlayed || videoEnded) && (time !== 0);
+      // [PBW-5539] On iOS, when triggering replay after the current browser tab looses focus, the
+      // current time seems to fall a few milliseconds behind the video duration, which
+      // makes the video play for a fraction of a second and then stop again at the end.
+      // In this case we allow setting the initial time back to 0 as a workaround for this
+      var initialTimeRequired = OO.isIos && videoEnded && time === 0;
+
+      if (canSetInitialTime || initialTimeRequired) {
         initialTime.value = time;
         initialTime.reached = false;
 

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -405,8 +405,8 @@ require("../../../html5-common/js/utils/environment.js");
         // [PBW-3866] Some Android devices (mostly Nexus) cannot be seeked too early or the seeked event is
         // never raised, even if the seekable property returns an endtime greater than the seek time.
         // To avoid this, save seeking information for use later.
-        // [PBW-5539] Same issue with desktop Safari
-        if (OO.isAndroid || (OO.isSafari && !OO.isIos)) {
+        // [PBW-5539] Same issue with desktop Safari when setting initialTime after video ends
+        if (OO.isAndroid || (initialTimeRequired && !OO.isIos)) {
           queueSeek(initialTime.value);
         }
         else {


### PR DESCRIPTION
So this turned out to be a bug on Safari itself (iOS and Desktop). It can be reproduced with a raw HLS stream without even using V4. It's not necessary to share the video in order to trigger the bug, all that is needed is that you switch to a different tab after the video has ended.

My guess is that Safari unloads some resources in order to save some memory when you switch tabs. When you switch back to the original tab, Safari again calculates either `currentTime` or `duration` (or both), but gets it wrong. When replay is triggered at this point, there are technically a few milliseconds left of playback, so the video plays until the end instead of restarting.

The workaround is simply to allow setting an `initialTime` of 0 on iOS (this affects both iPad and iPhone btw) and desktop Safari. The `playback controller` is already setting the initial time when `REPLAY` is triggered, but I think values of 0 were excluded because it's supposed to be 0 by default.