### PR TITLE
[PBW-5470] - Setting preload to 'metadata' on desktop Safari

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -86,7 +86,16 @@ require("../../../html5-common/js/utils/environment.js");
       var video = $("<video>");
       video.attr("class", "video");
       video.attr("id", domId);
-      video.attr("preload", "none");
+
+      // [PBW-5470] On Safari, when preload is set to 'none' and the user switches to a
+      // different tab while the video is about to auto play, the browser stops playback but
+      // doesn't fire a 'pause' event, which causes the player to get stuck in 'buffering' state.
+      // Setting preload to 'metadata' (or 'auto') allows Safari to auto resume when the tab is refocused.
+      if (OO.isSafari && !OO.isIos) {
+        video.attr("preload", "metadata");
+      } else {
+        video.attr("preload", "none");
+      }
 
       video.css(css);
 

--- a/tests/unit/main_html5/factory-tests.js
+++ b/tests/unit/main_html5/factory-tests.js
@@ -30,6 +30,10 @@ describe('main_html5 factory tests', function () {
   var vtc = { EVENTS: { CAN_PLAY: "can_play" },
                         notify: function(){} };
 
+  afterEach(function() {
+    OO.isSafari = false;
+  });
+
   it('should contain parameter \'name\'', function () {
     expect(pluginFactory.name).to.be.ok();
   });
@@ -140,6 +144,15 @@ describe('main_html5 factory tests', function () {
     expect(element.getAttribute("preload")).to.eql("none");
     expect(element.getAttribute("loop")).to.not.be.ok();;
     expect(element.getAttribute("autoplay")).to.not.be.ok();;
+  });
+
+  // [PBW-5470]
+  it('should set preload to "metadata" on desktop Safari', function(){
+    OO.isSafari = true;
+    var parentElement = $("<div>");
+    pluginFactory.create(parentElement, "test", vtc, {});
+    var element = parentElement.children()[0];
+    expect(element.getAttribute("preload")).to.eql("metadata");
   });
 
   it('should remove list of encodings on destroy', function(){


### PR DESCRIPTION
This issue was caused by Safari stopping playback without firing a `pause` event when a new tab is focused. The player never finds out that the video is paused and it gets stuck in buffering state. After trying a lot of ugly workarounds, I noticed that this only happens when `preload` is set to `none`.

I spent some time looking for potential problems caused by switching `preload` to `metadata` on Safari, but I couldn't find any. The main side-effects of this are that `onLoadedMetadata` is fired earlier than usual and that `this.load` might not be called during `executePlay`. I checked the code and this seems to be ok, but please let me know in case I'm missing something.  