### PR TITLE
[PBW-6077][EDGE][MAIN_HTML5] CC-live module not registering live HLS stream CC

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -582,16 +582,18 @@ require("../../../html5-common/js/utils/environment.js");
         //If the captions are in-stream, we just need to enable them; Otherwise we must add them to the video ourselves.
         if (captions.inStream == true && _video.textTracks) {
           for (var i = 0; i < _video.textTracks.length; i++) {
-            if (_video.textTracks[i].kind === "captions") {
+            if (((OO.isSafari || OO.isEdge) && isLive) || _video.textTracks[i].kind === "captions") {
               _video.textTracks[i].mode = captionMode;
               _video.textTracks[i].oncuechange = onClosedCaptionCueChange;
             } else {
-             _video.textTracks[i].mode = OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED;
+              _video.textTracks[i].mode = OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED;
             }
           }
         } else if (!captions.inStream) {
           this.setClosedCaptionsMode(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
-          $(_video).append("<track class='" + TRACK_CLASS + "' kind='subtitles' label='" + captions.label + "' src='" + captions.src + "' srclang='" + captions.language + "' default>");
+          if (!OO.isEdge && !OO.isSafari) { // on Edge / Safari track has already been added
+            $(_video).append("<track class='" + TRACK_CLASS + "' kind='subtitles' label='" + captions.label + "' src='" + captions.src + "' srclang='" + captions.language + "' default>");
+          }
           if (_video.textTracks && _video.textTracks[0]) {
             _video.textTracks[0].mode = captionMode;
             //We only want to let the controller know of cue change if we aren't rendering cc from the plugin.
@@ -724,7 +726,7 @@ require("../../../html5-common/js/utils/environment.js");
       if (_video.textTracks && _video.textTracks.length > 0) {
         var languages = [];
         for (var i = 0; i < _video.textTracks.length; i++) {
-          if (_video.textTracks[i].kind === "captions") {
+          if (((OO.isSafari || OO.isEdge) && isLive) || _video.textTracks[i].kind === "captions") {
             var captionInfo = {
               language: "CC",
               inStream: true,

--- a/tests/unit/main_html5/wrapper-event-tests.js
+++ b/tests/unit/main_html5/wrapper-event-tests.js
@@ -17,6 +17,15 @@ describe('main_html5 wrapper tests', function () {
   jest.dontMock('../../../src/main/js/main_html5');
   require('../../../src/main/js/main_html5');
 
+  var closedCaptions = {
+    closed_captions_vtt: {
+      en: {
+        name: "English",
+        url: "http://ooyala.com"
+      }
+    }
+  };
+
   beforeEach(function() {
     vtc = new mock_vtc();
     parentElement = $("<div>");
@@ -25,8 +34,13 @@ describe('main_html5 wrapper tests', function () {
   });
 
   afterEach(function() {
-    OO.isSafari = false;
+    OO.isEdge = false;
     OO.isAndroid = false;
+    OO.isIos = false;
+    OO.isIE = false;
+    OO.isIE11Plus = false;
+    OO.isSafari = false;
+    OO.isChrome = false;
     OO.isFirefox = false;
     if (wrapper) { wrapper.destroy(); }
   });
@@ -196,14 +210,6 @@ describe('main_html5 wrapper tests', function () {
 
   it('should notify CAPTIONS_FOUND_ON_PLAYING on first video \'playing\' event with all available cc', function(){
     vtc.interface.EVENTS.CAPTIONS_FOUND_ON_PLAYING = "captionsFoundOnPlaying";
-    var closedCaptions = {
-      closed_captions_vtt: {
-        en: {
-          name: "English",
-          url: "http://ooyala.com"
-        }
-      }
-    };
     element.textTracks = [{ kind: "captions" }];
     wrapper.setClosedCaptions("en", closedCaptions, {mode: "hidden"});
     $(element).triggerHandler("playing");
@@ -216,16 +222,19 @@ describe('main_html5 wrapper tests', function () {
     }]);
   });
 
+  it('should notify CAPTIONS_FOUND_ON_PLAYING for live in-stream captions for Edge in a different way', function(){
+    OO.isEdge = true;
+    vtc.interface.EVENTS.CAPTIONS_FOUND_ON_PLAYING = "captionsFoundOnPlaying";
+    element.textTracks = [{}];
+    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS, true);
+    $(element).triggerHandler("playing"); // this adds in-stream captions
+
+    expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.CAPTIONS_FOUND_ON_PLAYING, {
+      languages: ['CC'], locale: { CC: 'In-Stream' }}]);
+  });
+
   it('should notify CLOSED_CAPTION_CUE_CHANGED from onClosedCaptionCueChange event on textTrack', function(){
     vtc.interface.EVENTS.CLOSED_CAPTION_CUE_CHANGED = "closedCaptionCueChange";
-    var closedCaptions = {
-      closed_captions_vtt: {
-        en: {
-          name: "English",
-          url: "http://ooyala.com"
-        }
-      }
-    };
     var event = {
       currentTarget: {
         activeCues: [{
@@ -243,14 +252,6 @@ describe('main_html5 wrapper tests', function () {
 
   it('should notify CLOSED_CAPTION_CUE_CHANGED from onClosedCaptionCueChange event on textTrack with all active cues', function(){
     vtc.interface.EVENTS.CLOSED_CAPTION_CUE_CHANGED = "closedCaptionCueChange";
-    var closedCaptions = {
-      closed_captions_vtt: {
-        en: {
-          name: "English",
-          url: "http://ooyala.com"
-        }
-      }
-    };
     var event = {
       currentTarget: {
         activeCues: [{


### PR DESCRIPTION
* Special cases for Safari and Edge to set closed captions for live video
* Don't add text tracks for VOD on Safari or Edge
* Updated unit tests