### PR TITLE
[PBW-6127] Avoiding duplicate CCs (native + external ones) and making sure we add new text tracks only when required

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -572,8 +572,6 @@ require("../../../html5-common/js/utils/environment.js");
         }
       }
 
-      var captionMode = (params && params.mode) || OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING;
-
       //Add the new closed captions if they are valid.
       var captionsFormat = "closed_captions_vtt";
       if (closedCaptions && closedCaptions[captionsFormat]) {

--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -506,7 +506,7 @@ describe('main_html5 wrapper tests', function () {
 
     wrapper.setClosedCaptions("en", closedCaptions, {mode: OO.CONSTANTS.CLOSED_CAPTIONS.HIDDEN}); // this adds external captions
     expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.HIDDEN);
-    expect(element.textTracks[1].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
+    expect(element.textTracks[1].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.HIDDEN);
   });
 
   it('should remove closed captions if language is null', function(){

--- a/tests/unit/main_html5/wrapper-event-tests.js
+++ b/tests/unit/main_html5/wrapper-event-tests.js
@@ -18,6 +18,7 @@ describe('main_html5 wrapper tests', function () {
   require('../../../src/main/js/main_html5');
 
   var closedCaptions = {
+    locale: {en: "English"},
     closed_captions_vtt: {
       en: {
         name: "English",
@@ -199,7 +200,7 @@ describe('main_html5 wrapper tests', function () {
   it('should notify CAPTIONS_FOUND_ON_PLAYING on first video \'playing\' event if video has cc', function(){
     element.textTracks = [{ kind: "captions" }];
     vtc.interface.EVENTS.CAPTIONS_FOUND_ON_PLAYING = "captionsFoundOnPlaying";
-    $(element).triggerHandler("playing");
+    $(element).triggerHandler("playing"); // this adds in-stream captions
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.CAPTIONS_FOUND_ON_PLAYING, {
       languages: ['CC'],
       locale: {
@@ -208,11 +209,13 @@ describe('main_html5 wrapper tests', function () {
     }]);
   });
 
-  it('should notify CAPTIONS_FOUND_ON_PLAYING on first video \'playing\' event with all available cc', function(){
+  it('should notify CAPTIONS_FOUND_ON_PLAYING on first video \'playing\' event for both live and external CCs on Safari (or Edge)', function(){
+    OO.isSafari = true;
     vtc.interface.EVENTS.CAPTIONS_FOUND_ON_PLAYING = "captionsFoundOnPlaying";
-    element.textTracks = [{ kind: "captions" }];
-    wrapper.setClosedCaptions("en", closedCaptions, {mode: "hidden"});
-    $(element).triggerHandler("playing");
+    element.textTracks = [{ language: "en", label: "English", kind: "subtitles" }]; // this is external CC
+    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS, true); // sets isLive flag to true
+    wrapper.setClosedCaptions("en", closedCaptions, {mode: "hidden"}); // creates text tracks for external CCs
+    $(element).triggerHandler("playing"); // adds in-stream captions
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.CAPTIONS_FOUND_ON_PLAYING, {
       languages: ['en', 'CC'],
       locale: {


### PR DESCRIPTION
* Fixes in setClosedCaptions:
 ** Do not remove text tracks unless language is null
 ** Remove text tracks before setting new ones if they are different from to-be added, otherwise we may see native closed captions
 ** Create new text tracks only if they don't exist
* Do not remove text tracks if CC mode is disabled, setting text tracks mode to disabled is efficient.
* Updated unit tests