### PR TITLE
[PBW-6200] - Fixes stuck loading spinner on Edge

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -532,6 +532,7 @@ require("../../../html5-common/js/utils/environment.js");
      */
     this.destroy = function() {
       _video.pause();
+      stopUnderflowWatcher();
       //On IE and Edge, setting the video source to an empty string has the unwanted effect
       //of a network request to the base url
       if (!OO.isIE && !OO.isEdge) {

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -194,7 +194,6 @@ require("../../../html5-common/js/utils/environment.js");
     var isLive = false;
     var lastCueText = null;
     var availableClosedCaptions = {};
-    var lastTimeUpdate = 0;
 
     // Watch for underflow on Chrome
     var underflowWatcherTimer = null;
@@ -1017,15 +1016,6 @@ require("../../../html5-common/js/utils/environment.js");
      * @param {object} event The event from the video
      */
     var raiseTimeUpdate = _.bind(function(event) {
-      // [PBW-6200] - MS Edge will not fire 'playing' or 'canplaythrough' events after seeking.
-      // If playback progresses and 'waitingEventRaised' hasn't been cleared, we fire a
-      // 'buffered' event in order to notify that the video has stopped buffering
-      if (OO.isEdge && waitingEventRaised && lastTimeUpdate !== _video.currentTime) {
-        waitingEventRaised = false;
-        this.controller.notify(this.controller.EVENTS.BUFFERED, { "url": _video.currentSrc });
-      }
-      lastTimeUpdate = _video.currentTime;
-
       if (!isSeeking) {
         currentTime = _video.currentTime;
       }

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -194,6 +194,7 @@ require("../../../html5-common/js/utils/environment.js");
     var isLive = false;
     var lastCueText = null;
     var availableClosedCaptions = {};
+    var lastTimeUpdate = 0;
 
     // Watch for underflow on Chrome
     var underflowWatcherTimer = null;
@@ -1019,10 +1020,11 @@ require("../../../html5-common/js/utils/environment.js");
       // [PBW-6200] - MS Edge will not fire 'playing' or 'canplaythrough' events after seeking.
       // If playback progresses and 'waitingEventRaised' hasn't been cleared, we fire a
       // 'buffered' event in order to notify that the video has stopped buffering
-      if (waitingEventRaised && currentTime !== _video.currentTime) {
+      if (waitingEventRaised && lastTimeUpdate !== _video.currentTime) {
         waitingEventRaised = false;
         this.controller.notify(this.controller.EVENTS.BUFFERED, { "url": _video.currentSrc });
       }
+      lastTimeUpdate = _video.currentTime;
 
       if (!isSeeking) {
         currentTime = _video.currentTime;

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -1020,7 +1020,7 @@ require("../../../html5-common/js/utils/environment.js");
       // [PBW-6200] - MS Edge will not fire 'playing' or 'canplaythrough' events after seeking.
       // If playback progresses and 'waitingEventRaised' hasn't been cleared, we fire a
       // 'buffered' event in order to notify that the video has stopped buffering
-      if (waitingEventRaised && lastTimeUpdate !== _video.currentTime) {
+      if (OO.isEdge && waitingEventRaised && lastTimeUpdate !== _video.currentTime) {
         waitingEventRaised = false;
         this.controller.notify(this.controller.EVENTS.BUFFERED, { "url": _video.currentSrc });
       }

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -924,8 +924,8 @@ require("../../../html5-common/js/utils/environment.js");
      */
     var raiseWaitingEvent = _.bind(function() {
       // WAITING event is not raised if no video is assigned yet
-      if (_.isEmpty(_video.currentSrc)) { 
-        return; 
+      if (_.isEmpty(_video.currentSrc)) {
+        return;
       }
       waitingEventRaised = true;
       this.controller.notify(this.controller.EVENTS.WAITING, {"url":_video.currentSrc});
@@ -993,7 +993,7 @@ require("../../../html5-common/js/utils/environment.js");
       }
       if (videoEnded) { return; } // no double firing ended event.
       videoEnded = true;
-      initialTime.value = 0; 
+      initialTime.value = 0;
 
       this.controller.notify(this.controller.EVENTS.ENDED);
     }, this);
@@ -1016,6 +1016,14 @@ require("../../../html5-common/js/utils/environment.js");
      * @param {object} event The event from the video
      */
     var raiseTimeUpdate = _.bind(function(event) {
+      // [PBW-6200] - MS Edge will not fire 'playing' or 'canplaythrough' events after seeking.
+      // If playback progresses and 'waitingEventRaised' hasn't been cleared, we fire a
+      // 'buffered' event in order to notify that the video has stopped buffering
+      if (waitingEventRaised && currentTime !== _video.currentTime) {
+        waitingEventRaised = false;
+        this.controller.notify(this.controller.EVENTS.BUFFERED, { "url": _video.currentSrc });
+      }
+
       if (!isSeeking) {
         currentTime = _video.currentTime;
       }
@@ -1389,7 +1397,7 @@ require("../../../html5-common/js/utils/environment.js");
      * @method OoyalaVideoWrapper#startUnderflowWatcher
      */
     var startUnderflowWatcher = _.bind(function() {
-      if ((OO.isChrome || OO.isIos || OO.isIE11Plus) && !underflowWatcherTimer) {
+      if ((OO.isChrome || OO.isIos || OO.isIE11Plus || OO.isEdge) && !underflowWatcherTimer) {
         var watchInterval = 300;
         underflowWatcherTimer = setInterval(underflowWatcher, watchInterval)
       }

--- a/tests/unit/main_html5/underflow-tests.js
+++ b/tests/unit/main_html5/underflow-tests.js
@@ -34,6 +34,7 @@ describe('main_html5 chrome underflow tests', function () {
     OO.isFirefox = false;
     OO.isIos = false;
     OO.isIE11Plus = false;
+    OO.isEdge = false;
     vtc = new mock_vtc();
     parentElement = $("<div>");
     wrapper = pluginFactory.create(parentElement, "test", vtc.interface, {});
@@ -455,6 +456,20 @@ describe('main_html5 chrome underflow tests', function () {
     expect(_.contains(vtc.notified, vtc.interface.EVENTS.WAITING)).to.be(false);
     jasmine.Clock.tick(interval);
     expect(_.contains(vtc.notified, vtc.interface.EVENTS.WAITING)).to.be(true);
+  });
+
+  it('should raise buffered event after waiting on MS Edge when currentTime has progressed', function(){
+    OO.isChrome = false;
+    OO.isEdge = true;
+    vtc.interface.EVENTS.BUFFERED = "buffered";
+    element.currentSrc = "url";
+    wrapper.play();
+    $(element).triggerHandler("playing");
+    $(element).triggerHandler("waiting");
+    element.currentTime = 10;
+    $(element).triggerHandler("timeupdate");
+    jasmine.Clock.tick(interval);
+    expect(_.contains(vtc.notified, vtc.interface.EVENTS.BUFFERED)).to.be(true);
   });
 
   it('should not raise waiting event when the currentTime hasn\'t progressed on most platforms', function(){

--- a/tests/unit/main_html5/wrapper-event-tests.js
+++ b/tests/unit/main_html5/wrapper-event-tests.js
@@ -40,7 +40,6 @@ describe('main_html5 wrapper tests', function () {
     OO.isIos = false;
     OO.isIE = false;
     OO.isIE11Plus = false;
-    OO.isEdge = false;
     OO.isSafari = false;
     OO.isChrome = false;
     OO.isFirefox = false;
@@ -181,42 +180,6 @@ describe('main_html5 wrapper tests', function () {
     element.currentSrc = "url";
     $(element).triggerHandler("canplaythrough");
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.BUFFERED, { url : "url" }]);
-  });
-
-  it('should notify BUFFERED on MS Edge when a frame plays after a waiting event', function(){
-    OO.isEdge = true;
-    vtc.interface.EVENTS.BUFFERED = "buffered";
-    element.currentSrc = "url";
-    $(element).triggerHandler("waiting");
-    element.currentTime = 10;
-    $(element).triggerHandler("timeupdate");
-    expect(_.contains(vtc.notified, vtc.interface.EVENTS.BUFFERED)).to.be(true);
-  });
-
-  it('should NOT notify BUFFERED on MS Edge when a frame plays without a previous waiting event', function(){
-    OO.isEdge = true;
-    vtc.interface.EVENTS.BUFFERED = "buffered";
-    element.currentSrc = "url";
-    element.currentTime = 10;
-    $(element).triggerHandler("timeupdate");
-    expect(_.contains(vtc.notified, vtc.interface.EVENTS.BUFFERED)).to.be(false);
-  });
-
-  it('should notify BUFFERED only once on MS Edge when a frame plays after a canplaythrough event', function(){
-    OO.isEdge = true;
-    vtc.interface.EVENTS.BUFFERED = "buffered";
-    element.currentSrc = "url";
-    $(element).triggerHandler("waiting");
-    $(element).triggerHandler("canplaythrough");
-    element.currentTime = 10;
-    $(element).triggerHandler("timeupdate");
-    var bufferedCount = 0
-    _.each(vtc.notified, function(event) {
-      if (event === vtc.interface.EVENTS.BUFFERED) {
-        bufferedCount++;
-      }
-    });
-    expect(bufferedCount).to.be(1);
   });
 
   it('should notify PLAYING on video \'playing\' event', function(){

--- a/tests/unit/main_html5/wrapper-event-tests.js
+++ b/tests/unit/main_html5/wrapper-event-tests.js
@@ -40,6 +40,7 @@ describe('main_html5 wrapper tests', function () {
     OO.isIos = false;
     OO.isIE = false;
     OO.isIE11Plus = false;
+    OO.isEdge = false;
     OO.isSafari = false;
     OO.isChrome = false;
     OO.isFirefox = false;
@@ -180,6 +181,42 @@ describe('main_html5 wrapper tests', function () {
     element.currentSrc = "url";
     $(element).triggerHandler("canplaythrough");
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.BUFFERED, { url : "url" }]);
+  });
+
+  it('should notify BUFFERED on MS Edge when a frame plays after a waiting event', function(){
+    OO.isEdge = true;
+    vtc.interface.EVENTS.BUFFERED = "buffered";
+    element.currentSrc = "url";
+    $(element).triggerHandler("waiting");
+    element.currentTime = 10;
+    $(element).triggerHandler("timeupdate");
+    expect(_.contains(vtc.notified, vtc.interface.EVENTS.BUFFERED)).to.be(true);
+  });
+
+  it('should NOT notify BUFFERED on MS Edge when a frame plays without a previous waiting event', function(){
+    OO.isEdge = true;
+    vtc.interface.EVENTS.BUFFERED = "buffered";
+    element.currentSrc = "url";
+    element.currentTime = 10;
+    $(element).triggerHandler("timeupdate");
+    expect(_.contains(vtc.notified, vtc.interface.EVENTS.BUFFERED)).to.be(false);
+  });
+
+  it('should notify BUFFERED only once on MS Edge when a frame plays after a canplaythrough event', function(){
+    OO.isEdge = true;
+    vtc.interface.EVENTS.BUFFERED = "buffered";
+    element.currentSrc = "url";
+    $(element).triggerHandler("waiting");
+    $(element).triggerHandler("canplaythrough");
+    element.currentTime = 10;
+    $(element).triggerHandler("timeupdate");
+    var bufferedCount = 0
+    _.each(vtc.notified, function(event) {
+      if (event === vtc.interface.EVENTS.BUFFERED) {
+        bufferedCount++;
+      }
+    });
+    expect(bufferedCount).to.be(1);
   });
 
   it('should notify PLAYING on video \'playing\' event', function(){
@@ -353,7 +390,7 @@ describe('main_html5 wrapper tests', function () {
     $(element).triggerHandler("waiting");
     expect(_.contains(vtc.notified, vtc.interface.EVENTS.WAITING)).to.be(false);
   });
-  
+
   it('should notify SEEKING on video \'seeking\' event', function(){
     vtc.interface.EVENTS.SEEKING = "seeking";
     $(element).triggerHandler("seeking");


### PR DESCRIPTION
[Link to ticket](https://jira.corp.ooyala.com/browse/PBW-6200)

The problem was caused by the fact that MS Edge doesn't trigger `playing` or `canplaythrough` after seeking ([example](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/6168727/)), so the buffering state was not being reset. It's also worth noting that `canplaythrough` [isn't properly implemented on all browsers](https://bugs.chromium.org/p/chromium/issues/detail?id=73609), so it's probably better not to rely on it too much. 

The `playing` event seemed like a good place to raise the `BUFFERED` event, but according to the spec, it is not necessarily supposed to be fired after seeking. This means that the only way to determine whether the video has resumed after buffering is to check that `currentTime` is getting updated on the `timeupdate` event.