### PR TITLE
[PBW-4456] Removes unit test that was in direct conflict with the goa…

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -695,7 +695,6 @@ require("../../../html5-common/js/utils/environment.js");
       stopUnderflowWatcher();
       _currentUrl = _video.src;
       firstPlay = true;
-      videoEnded = false;
       isSeeking = false;
     }, this);
 

--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -237,6 +237,20 @@ describe('main_html5 wrapper tests', function () {
     expect(element.load.wasCalled).to.be(true);
   });
 
+  it('should unblock raising of ended event after calling play', function(){
+    vtc.interface.EVENTS.ENDED = "ended";
+    $(element).triggerHandler("ended");
+    expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.ENDED]);
+    vtc.notifyParameters = null;
+    $(element).triggerHandler("ended");
+    expect(vtc.notifyParameters).to.eql(null);
+    $(element).triggerHandler("loadstart");
+    expect(vtc.notifyParameters).to.eql(null);
+    wrapper.play();
+    $(element).triggerHandler("ended");
+    expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.ENDED]);
+  });
+
   it('should not play if seeking', function(){
     element.seeking = true;
     spyOn(element, "play");

--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -245,6 +245,7 @@ describe('main_html5 wrapper tests', function () {
     $(element).triggerHandler("ended");
     expect(vtc.notifyParameters).to.eql(null);
     $(element).triggerHandler("loadstart");
+    $(element).triggerHandler("ended");
     expect(vtc.notifyParameters).to.eql(null);
     wrapper.play();
     $(element).triggerHandler("ended");

--- a/tests/unit/main_html5/wrapper-event-tests.js
+++ b/tests/unit/main_html5/wrapper-event-tests.js
@@ -487,18 +487,6 @@ describe('main_html5 wrapper tests', function () {
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.ENDED]);
   });
 
-  it('should unblock raising of ended event after a new stream begins loading', function(){
-    vtc.interface.EVENTS.ENDED = "ended";
-    $(element).triggerHandler("ended");
-    expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.ENDED]);
-    vtc.notifyParameters = null;
-    $(element).triggerHandler("ended");
-    expect(vtc.notifyParameters).to.eql(null);
-    $(element).triggerHandler("loadstart");
-    $(element).triggerHandler("ended");
-    expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.ENDED]);
-  });
-
   // TODO: When we have platform testing support, test for iOS behavior for ended event raised when ended != true
 
   it('should block seekable from playheads until video initialization in safari', function(){


### PR DESCRIPTION
Removes unit test that was in direct conflict with the goal of what PBW-4456 was attempting to do.

The unit test was designed for:
"unblock raising of ended event after a new stream begins loading"

And PBW-4456 was aiming to:
"Removed duplicate videoEnded=false that was confusing player on replay. videoEnded=false remain in executePlay where it belongs."

In other words the video ended event should remain blocked at "onLoadStart". I should only be unblocked when actual play begins.