### PR TITLE
[PBW-6266]Problem switching between a number of videos on the same page

### DIFF
--- a/src/youtube/js/youtube.js
+++ b/src/youtube/js/youtube.js
@@ -369,6 +369,8 @@ require("../../../html5-common/js/utils/constants.js");
       youtubePlayer.destroy();
       youtubePlayer = null;
       playerReady = false;
+      clearInterval(timeUpdateInterval);
+      timeUpdateInterval = null;
     };
 
     /**

--- a/src/youtube/js/youtube.js
+++ b/src/youtube/js/youtube.js
@@ -366,8 +366,10 @@ require("../../../html5-common/js/utils/constants.js");
         youtubeID = '';
       }
       player = null;
-      youtubePlayer.destroy();
-      youtubePlayer = null;
+      if (youtubePlayer) {
+        youtubePlayer.destroy();
+        youtubePlayer = null;
+      }
       playerReady = false;
       clearInterval(timeUpdateInterval);
       timeUpdateInterval = null;

--- a/src/youtube/js/youtube.js
+++ b/src/youtube/js/youtube.js
@@ -273,8 +273,10 @@ require("../../../html5-common/js/utils/constants.js");
     this.pause = function() {
       if(!youtubePlayer) return;
       youtubePlayer.pauseVideo();
-      clearInterval(timeUpdateInterval);
-      timeUpdateInterval = null;
+      if (timeUpdateInterval) {
+        clearInterval(timeUpdateInterval);
+        timeUpdateInterval = null;
+      }
     };
     
     /**
@@ -371,8 +373,10 @@ require("../../../html5-common/js/utils/constants.js");
         youtubePlayer = null;
       }
       playerReady = false;
-      clearInterval(timeUpdateInterval);
-      timeUpdateInterval = null;
+      if (timeUpdateInterval) {
+        clearInterval(timeUpdateInterval);
+        timeUpdateInterval = null;
+      }
     };
 
     /**
@@ -382,7 +386,9 @@ require("../../../html5-common/js/utils/constants.js");
      */
     var updateTimerDisplay = function() {
       if(!youtubePlayer || !playerReady) return;
-      clearInterval(timeUpdateInterval);
+      if (timeUpdateInterval) {
+        clearInterval(timeUpdateInterval);
+      }
       timeUpdateInterval = setInterval(function () { updateTimerDisplay(); }, 255);
       raisePlayhead();
     };


### PR DESCRIPTION
* When plugin was destroyed, setInterval was still generating TIME_UPDATE events for stale instance of VTC (which is supposed to be garbage-collected at some point, but it didn't because it was still being used).  This orphaned VTC object was trying to obtain isLive property from non-existing active instance in order to publish PLAYHEAD_TIME_CHANGED events for skin, which resulted in numerous JS exceptions.  Fix is to clear this interval when plugin is being disposed.