### PR TITLE
[PLAYER-212] - Clearing closed captions when new video is set

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -343,6 +343,11 @@ require("../../../html5-common/js/utils/environment.js");
       isPriming = false;
       stopUnderflowWatcher();
       lastCueText = null;
+      // [PLAYER-212]
+      // Closed captions persist across discovery videos unless they are cleared
+      // when a new video is set
+      $(_video).find('.' + TRACK_CLASS).remove();
+      availableClosedCaptions = {};
     }, this);
 
     /**

--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -91,6 +91,24 @@ describe('main_html5 wrapper tests', function () {
     expect(returns).to.be(false);
   });
 
+  it('should clear closed captions when setting a new url', function(){
+    wrapper.setVideoUrl("url");
+    wrapper.setClosedCaptions(language, closedCaptions, params);
+    // Make sure tracks are actually there before we remove them
+    expect(element.children.length > 0).to.be(true);
+    expect(element.children[0].tagName).to.eql("TRACK");
+    wrapper.setVideoUrl("new_url");
+    expect(element.children.length).to.be(0);
+  });
+
+  it('should not clear closed captions when setting the same url', function(){
+    wrapper.setVideoUrl("url");
+    wrapper.setClosedCaptions(language, closedCaptions, params);
+    wrapper.setVideoUrl("url");
+    expect(element.children.length > 0).to.be(true);
+    expect(element.children[0].tagName).to.eql("TRACK");
+  });
+
   it('should ignore cache buster', function(){
     wrapper.setVideoUrl("url?_=1");
     var returns = wrapper.setVideoUrl("url");
@@ -287,7 +305,7 @@ describe('main_html5 wrapper tests', function () {
     wrapper.setVideoUrl("url", "mp4", false);
     element.duration = 0;
     setFullSeekRange(10);
-    var returns = wrapper.seek(1);    
+    var returns = wrapper.seek(1);
     expect(returns).to.be(true);
     element.duration = Infinity;
     returns = wrapper.seek(1);
@@ -548,7 +566,7 @@ describe('main_html5 wrapper tests', function () {
     expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
     expect(element.textTracks[1].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
 
-    wrapper.setClosedCaptions("CC", null, {mode: OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING}); 
+    wrapper.setClosedCaptions("CC", null, {mode: OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING});
     expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING);
     expect(element.textTracks[1].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING);
 


### PR DESCRIPTION
[Link to ticket](https://jira.corp.ooyala.com/browse/PLAYER-212)

Continuous playback on mobile requires that the same video element be used for all videos, otherwise a user gesture would be required to initiate playback on each one. I made some changes to the core in order to recycle the video element, but this caused closed captions to reappear on new videos because the text tracks hadn't been cleared.

I updated *main_html5* so that the captions are cleared when a new video is set, with the assumption that we no longer need the captions from the previous video. This appears to be working  fine, but please let me know in case I'm missing something here.

Related PR's:
https://git.corp.ooyala.com/projects/PBW/repos/mjolnir/pull-requests/168
https://github.com/ooyala/html5-skin/pull/704