### PR TITLE
[PLAYER-327][PLAYER-73] -Workaround for duplicate CC's

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -569,12 +569,14 @@ require("../../../html5-common/js/utils/environment.js");
       var useOldLogic = (iosVersion && iosVersion < 10) || (macOsSafariVersion && macOsSafariVersion < 10);
       if (useOldLogic) { // XXX HACK! PLAYER-54 iOS and OSX Safari versions < 10 require re-creation of textTracks every time this function is called
         $(_video).find('.' + TRACK_CLASS).remove();
+        textTrackModes = {};
         if (language == null) {
           return;
         }
       } else {
         if (language == null) {
           $(_video).find('.' + TRACK_CLASS).remove();
+          textTrackModes = {};
           return;
         }
         // Remove captions before setting new ones if they are different, otherwise we may see native closed captions
@@ -621,7 +623,7 @@ require("../../../html5-common/js/utils/environment.js");
             // We keep track of all text track modes in order to prevent Safari from randomly
             // changing them. We can't set the id of inStream tracks, so we use a custom
             // trackId property instead
-            trackId = _video.textTracks[i].id || OO.getRandomString();
+            trackId = _video.textTracks[i].id || _video.textTracks[i].trackId || OO.getRandomString();
             _video.textTracks[i].trackId = trackId;
             textTrackModes[trackId] = _video.textTracks[i].mode;
           }
@@ -746,6 +748,10 @@ require("../../../html5-common/js/utils/environment.js");
     var onTextTracksChange = _.bind(function(event) {
       for (var i = 0; i < _video.textTracks.length; i++) {
         var trackId = _video.textTracks[i].id || _video.textTracks[i].trackId;
+
+        if (typeof textTrackModes[trackId] === 'undefined') {
+          continue;
+        }
         // [PLAYER-327], [PLAYER-73]
         // Safari (desktop and iOS) sometimes randomly switches a track's mode. As a
         // workaround, we force our own value if we detect that we have switched

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -740,7 +740,8 @@ require("../../../html5-common/js/utils/environment.js");
     /**
      * Fired when there is a change on a text track.
      * @private
-     * @param  {object} function(event description
+     * @method OoyalaVideoWrapper#onTextTracksChange
+     * @param {object} event The event from the track change
      */
     var onTextTracksChange = _.bind(function(event) {
       for (var i = 0; i < _video.textTracks.length; i++) {

--- a/tests/utils/test_lib.js
+++ b/tests/utils/test_lib.js
@@ -2,6 +2,7 @@ jest.dontMock('underscore');
 jest.dontMock('jquery');
 
 global.OO = { publicApi: {}, platform: 'MacIntel', os: {}, browser: { version:1, webkit:true }, TEST_TEST_TEST: true};
+global.OO.getRandomString = function() { return Math.random().toString(36).substring(7); };
 
 // The function setTimeout from jsdom is not working, this overwrites the function with the function defined by node
 global.window.setTimeout = setTimeout;


### PR DESCRIPTION
Related tickets:
[PLAYER-327](https://jira.corp.ooyala.com/browse/PLAYER-327)
[PLAYER-73](https://jira.corp.ooyala.com/browse/PLAYER-73)

Possibly also: [PBW-5682](https://jira.corp.ooyala.com:8443/browse/PBW-5682) 

It looks like this is a bug in Safari that is possibly triggered by adding and removing tracks, although I couldn't really find a good explanation for the cause. There are two main problems that can be observed in Safari:

- Even though _Track_ elements are successfully removed, every now and then the corresponding _TextTrack_ object will remain, and it will get duplicated once a new one is added. This is usually not a problem in itself since the code already has logic that disables  previous tracks though.
- For some reason Safari will randomly choose to change the mode of a track from either _disabled_ or _hidden_ to _showing_. This happens consistently when showing midrolls or postrolls on iOS and it also happens randomly when playing or even after pausing the video. 

I couldn't find a way to prevent Safari from doing this. I had to resort instead to keeping track of each track's mode and forcing these values whenever Safari tries to change them. It's a bit hacky unfortunately, but this should technically only take effect if Safari does something wrong.