### PR TITLE
[PLAYER-1323] Video preloading fixes

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -196,6 +196,7 @@ require("../../../html5-common/js/utils/environment.js");
     var lastCueText = null;
     var availableClosedCaptions = {};
     var textTrackModes = {};
+    var originalPreloadValue = $(_video).attr("preload") || "none";
 
     // Watch for underflow on Chrome
     var underflowWatcherTimer = null;
@@ -341,6 +342,9 @@ require("../../../html5-common/js/utils/environment.js");
       stopUnderflowWatcher();
       lastCueText = null;
       textTrackModes = {};
+      // Restore the preload attribute to the value it had when the video
+      // element was created
+      $(_video).attr("preload", originalPreloadValue);
       // [PLAYER-212]
       // Closed captions persist across discovery videos unless they are cleared
       // when a new video is set
@@ -391,6 +395,11 @@ require("../../../html5-common/js/utils/environment.js");
         }
       }
       canPlay = false;
+      // The load() method might still be affected by the value of the preload attribute in
+      // some browsers (i.e. it might determine how much data is actually loaded). We set preload to auto
+      // before loading in case that this.load() was called by VC_PRELOAD. If load() is called prior to
+      // starting playback this will be redundant, but it shouldn't cause any issues
+      $(_video).attr("preload", "auto");
       _video.load();
       loaded = true;
     };

--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -442,6 +442,53 @@ describe('main_html5 wrapper tests', function () {
     expect(element.pause.wasCalled).to.be(true);
   });
 
+  it('should wait for play promise to be resolved before pausing when priming on iOS', function(){
+    OO.isIos = true;
+    var thenCallback = null;
+    var originalPlayFunction = element.play;
+    // Replace mock play function with one that returns a promise
+    element.play = function() {
+      return {
+        then: function(callback) {
+          thenCallback = callback;
+        }
+      };
+    };
+    spyOn(element, "pause");
+    wrapper.load(false);
+    wrapper.primeVideoElement();
+    // Pause should not be called until promise is resolved
+    expect(element.pause.wasCalled).to.be(false);
+    thenCallback();
+    expect(element.pause.wasCalled).to.be(true);
+    // Restore original play function
+    element.play = originalPlayFunction;
+  });
+
+  it('should not pause when priming on iOS if playback has already been requested', function(){
+    OO.isIos = true;
+    var thenCallback = null;
+    var originalPlayFunction = element.play;
+    // Replace mock play function with one that returns a promise
+    element.play = function() {
+      return {
+        then: function(callback) {
+          thenCallback = callback;
+        }
+      };
+    };
+    spyOn(element, "pause");
+    wrapper.load(false);
+    wrapper.primeVideoElement();
+    // Simulating that play() gets called before the original video.play promise from
+    // the priming call is resolved
+    wrapper.play();
+    thenCallback();
+    expect(element.pause.wasCalled).to.be(false);
+    // Restore original play function
+    element.play = originalPlayFunction;
+  });
+
   it('should append and change css', function(){
     var css = { "visibility" : "hidden" };
     wrapper.applyCss(css);

--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -109,6 +109,14 @@ describe('main_html5 wrapper tests', function () {
     expect(element.children[0].tagName).to.eql("TRACK");
   });
 
+  it('should restore preload attribute when setting a new url', function(){
+    var originalPreloadValue = element.getAttribute("preload");
+    wrapper.setVideoUrl("url1");
+    wrapper.load(false);
+    wrapper.setVideoUrl("url2");
+    expect(element.getAttribute("preload")).to.equal(originalPreloadValue);
+  });
+
   it('should ignore cache buster', function(){
     wrapper.setVideoUrl("url?_=1");
     var returns = wrapper.setVideoUrl("url");
@@ -213,6 +221,12 @@ describe('main_html5 wrapper tests', function () {
     expect(element.pause.callCount).to.eql(0);
     expect(element.load.callCount).to.eql(1);
     expect(element.currentTime).to.eql(10);
+  });
+
+  it('should set preload to auto when loading', function(){
+    element.src = "url";
+    wrapper.load(false);
+    expect(element.getAttribute("preload")).to.equal("auto");
   });
 
   it('should act on initialTime if has not played', function(){


### PR DESCRIPTION
- Added `preload=auto` to the video element in order allow preloading the full content when available
- Fixed an issue where playback would freeze when priming a video on iOS with preloading on.