### PR TITLE
Rather than a console error, simply log if Flash is not detected

### DIFF
--- a/src/osmf/js/osmf_flash.js
+++ b/src/osmf/js/osmf_flash.js
@@ -81,7 +81,7 @@ require("../../../html5-common/js/utils/constants.js");
     function testForFlash() {
       var version = getFlashVersion().split(',').shift();
       if (version < 11) {
-        console.error("NO FLASH DETECTED");
+        OO.log('OSMF: Flash not detected');
         return [];
       } else {
         return [ OO.VIDEO.ENCODING.HDS ];


### PR DESCRIPTION
To get cleaner console output; this is almost certainly not a fatal error, unless there is no other video plugin included.