### PR TITLE
[PBW-6882] Workaround for Safari CORS issues on iOS 11

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -755,7 +755,19 @@ require("../../../html5-common/js/utils/environment.js");
      */
     this.setCrossorigin = function(crossorigin) {
       if (crossorigin) {
-        $(_video).attr("crossorigin", crossorigin);
+        // [PBW-6882]
+        // There's a strange bug in Safari on iOS11 that causes CORS errors to be
+        // incorrectly thrown when setting the crossorigin attribute after a video has
+        // played without it. This usually happens when a video with CC's is played
+        // after a preroll that's not using crossorigin.
+        // At the time of writing iOS Safari doesn't seem to enforce same origin policy
+        // for either HLS manifests/segments or VTT files. We avoid setting crossorigin
+        // as a workaround for iOS 11 since it currently appears to not be needed.
+        var isIos11 = OO.isIos && OO.iosMajorVersion === 11;
+
+        if (!isIos11) {
+          $(_video).attr("crossorigin", crossorigin);
+        }
       } else {
         $(_video).removeAttr("crossorigin");
       }

--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -682,6 +682,19 @@ describe('main_html5 wrapper tests', function () {
     expect(element.getAttribute("crossorigin")).to.not.be.ok();
   });
 
+  it('should NOT set the crossorigin attribute on iOS 11', function(){
+    OO.isIos = true;
+    OO.iosMajorVersion = 11;
+    expect(element.getAttribute("crossorigin")).to.not.be.ok();
+    wrapper.setCrossorigin("anonymous");
+    expect(element.getAttribute("crossorigin")).to.not.be.ok();
+    // Clearing crossorigin should still work
+    element.setAttribute("crossorigin", "anonymous");
+    expect(element.getAttribute("crossorigin")).to.be("anonymous");
+    wrapper.setCrossorigin(null);
+    expect(element.getAttribute("crossorigin")).to.not.be.ok();
+  });
+
   it('should return current time on getCurrentTime', function(){
     element.currentTime = 10;
     expect(wrapper.getCurrentTime()).to.eql(10);


### PR DESCRIPTION
There's a strange bug in Safari on iOS11 that causes CORS errors to be  incorrectly thrown when setting the `crossorigin` attribute after a video has played without it. This usually happens when a video with CC's is played after a preroll that's not using `crossorigin`.

For some reason it seems that Safari is not enforcing same origin policy for VTT files, so at least for now it seems that it's safe to just prevent Safari from setting the `crossorigin` attribute at all.