### PR TITLE
[PLAYER-404] Add DVR support to MainHtml5

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -1173,11 +1173,8 @@ require("../../../html5-common/js/utils/environment.js");
       // using the native player controls. We haven't updated currentTimeShift in this case,
       // so we do it at this point in order to show the correct shift in our inline controls
       // when the user exits fullscreen mode.
-      if (
-        isLive &&
-        isDvrAvailable() &&
-        !isWrapperSeeking // Seeking wasn't initiated by the wrapper, which means this is a native seek
-      ) {
+      if (isDvrAvailable() && !isWrapperSeeking) {
+        // Seeking wasn't initiated by the wrapper, which means this is a native seek
         currentTimeShift = getTimeShift(_video.currentTime);
       }
       isWrapperSeeking = false;
@@ -1605,7 +1602,7 @@ require("../../../html5-common/js/utils/environment.js");
 
       // Live videos without DVR (i.e. maxTimeShift === 0) are treated as regular
       // videos for playhead update purposes
-      if (isLive && isDvrAvailable()) {
+      if (isDvrAvailable()) {
         var maxTimeShift = getMaxTimeShift();
         newCurrentTime = currentTimeShift - maxTimeShift;
         duration = -maxTimeShift;

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -1610,7 +1610,7 @@ require("../../../html5-common/js/utils/environment.js");
         buffer = duration;
         // [PBW-5863] The skin displays current time a bit differently when dealing
         // with live video, but we still need to keep track of the actual playhead for analytics purposes
-        currentLiveTime = video.currentTime;
+        currentLiveTime = _video.currentTime;
       } else {
         if (_video.buffered && _video.buffered.length > 0) {
           buffer = _video.buffered.end(0); // in seconds
@@ -1640,6 +1640,9 @@ require("../../../html5-common/js/utils/environment.js");
      */
     var ensureNumber = function(value, defaultValue) {
       var number;
+      if (value === null || _.isArray(value)) {
+        value = NaN;
+      }
       if (_.isNumber(value)) {
         number = value;
       } else {

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -1549,6 +1549,9 @@ require("../../../html5-common/js/utils/environment.js");
      * if currently at the live edge.
      */
     var getTimeShift = function(currentTime) {
+      if (!isLive) {
+        return 0;
+      }
       var timeShift = 0;
       var seekRange = getSafeSeekRange(getSafeSeekableObject());
       // If not a valid number set to seekRange.end so that timeShift equals zero
@@ -1568,12 +1571,11 @@ require("../../../html5-common/js/utils/environment.js");
      * represented as a negative number, or zero, if DVR is not available.
      */
     var getMaxTimeShift = function(event) {
-      var seekRange = getSafeSeekRange(getSafeSeekableObject());
-      if (!isLive || !seekRange) {
+      if (!isLive) {
         return 0;
       }
-      // Get time shift and convert to negative
       var maxShift = 0;
+      var seekRange = getSafeSeekRange(getSafeSeekableObject());
       maxShift = seekRange.end - seekRange.start;
       maxShift = ensureNumber(maxShift, 0) > 0 ? -maxShift : 0;
       return maxShift;

--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -316,9 +316,19 @@ describe('main_html5 wrapper tests', function () {
     spyOn(element.seekable, "start").andReturn(0);
     spyOn(element.seekable, "end").andReturn(0);
     wrapper.setVideoUrl("url", "mp4", true);
-    element.duration = 100;
+    element.duration = Infinity;
     var returns = wrapper.seek(1);
     expect(returns).to.be(false);
+  });
+
+  it('should NOT ignore seek for live streams with DVR enabled', function() {
+    spyOn(element.seekable, "start").andReturn(0);
+    spyOn(element.seekable, "end").andReturn(1750);
+    element.seekable.length = 1;
+    wrapper.setVideoUrl("url", "mp4", true);
+    element.duration = Infinity;
+    var returns = wrapper.seek(1);
+    expect(returns).to.be(true);
   });
 
   it('should NOT ignore seek for VOD stream even if duration of video is zero or Infinity or NaN', function(){

--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -312,7 +312,9 @@ describe('main_html5 wrapper tests', function () {
     expect(returns).to.be(false);
   });
 
-  it('should ignore seek for live streams', function(){
+  it('should ignore seek for live streams with no DVR', function(){
+    spyOn(element.seekable, "start").andReturn(0);
+    spyOn(element.seekable, "end").andReturn(0);
     wrapper.setVideoUrl("url", "mp4", true);
     element.duration = 100;
     var returns = wrapper.seek(1);

--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -75,7 +75,25 @@ describe('main_html5 wrapper tests', function () {
     spyOn(element.seekable, "start").andReturn(0);
     spyOn(element.seekable, "end").andReturn(duration);
     element.seekable.length = 1;
-  }
+  };
+
+  var enableDvr = function(start, end) {
+    start = start || 0;
+    end = end || 1750;
+    var startSpy = spyOn(element.seekable, "start").andReturn(start);
+    var endSpy = spyOn(element.seekable, "end").andReturn(end);
+    element.seekable.length = 1;
+    element.duration = Infinity;
+    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS, true);
+    return {
+      restore: function() {
+        // TODO
+        // Our ancient version of Jest doesn't even support resetting spies
+        element.seekable.start = startSpy.originalValue;
+        element.seekable.end = endSpy.originalValue;
+      }
+    };
+  };
 
   // tests
 
@@ -321,14 +339,138 @@ describe('main_html5 wrapper tests', function () {
     expect(returns).to.be(false);
   });
 
-  it('should NOT ignore seek for live streams with DVR enabled', function() {
-    spyOn(element.seekable, "start").andReturn(0);
-    spyOn(element.seekable, "end").andReturn(1750);
-    element.seekable.length = 1;
-    wrapper.setVideoUrl("url", "mp4", true);
-    element.duration = Infinity;
-    var returns = wrapper.seek(1);
-    expect(returns).to.be(true);
+  it('DVR: should NOT ignore seek for live streams with DVR enabled', function() {
+    enableDvr();
+    expect(wrapper.seek(1)).to.be(true);
+  });
+
+  it('DVR: should NOT update currentTime when seek() is called with invalid value', function() {
+    enableDvr();
+    element.currentTime = 1000;
+    wrapper.seek(-1);
+    // JSDOM returns currentTime as string, browsers don't
+    expect(Number(element.currentTime)).to.be(1000);
+    wrapper.seek(-10);
+    expect(Number(element.currentTime)).to.be(1000);
+    wrapper.seek('w00t');
+    expect(Number(element.currentTime)).to.be(1000);
+    wrapper.seek();
+    expect(Number(element.currentTime)).to.be(1000);
+    wrapper.seek(null);
+    expect(Number(element.currentTime)).to.be(1000);
+    wrapper.seek({});
+    expect(Number(element.currentTime)).to.be(1000);
+    wrapper.seek([]);
+    expect(Number(element.currentTime)).to.be(1000);
+  });
+
+  it('DVR: should constrain seek time to DVR window', function() {
+    var dvrWindowStart = 500;
+    var dvrWindowSize = 1750;
+    var dvrWindowEnd = dvrWindowStart + dvrWindowSize;
+    enableDvr(dvrWindowStart, dvrWindowEnd);
+    element.currentTime = 1000;
+    wrapper.seek(dvrWindowSize);
+    // JSDOM returns currentTime as string, browsers don't
+    expect(Number(element.currentTime)).to.be(dvrWindowEnd);
+    wrapper.seek(0);
+    expect(Number(element.currentTime)).to.be(dvrWindowStart);
+    wrapper.seek(dvrWindowSize + 100);
+    expect(Number(element.currentTime)).to.be(dvrWindowEnd);
+  });
+
+  it('DVR: should calculate DVR seek time relative to DVR start and end values', function() {
+    var dvrWindowStart = 2000;
+    var dvrWindowSize = 2000;
+    var dvrWindowEnd = dvrWindowStart + dvrWindowSize;
+    enableDvr(dvrWindowStart, dvrWindowEnd);
+    element.currentTime = 3900;
+    wrapper.seek(dvrWindowSize / 2);
+    // JSDOM returns currentTime as string, browsers don't
+    expect(Number(element.currentTime)).to.be(dvrWindowStart + (dvrWindowSize / 2));
+    wrapper.seek(dvrWindowSize);
+    expect(Number(element.currentTime)).to.be(dvrWindowEnd);
+  });
+
+  it('DVR: should update time shift when seeking', function() {
+    var params;
+    var dvrWindowStart = 100;
+    var dvrWindowSize = 1600;
+    var dvrWindowEnd = dvrWindowStart + dvrWindowSize;
+    enableDvr(dvrWindowStart, dvrWindowEnd);
+    element.currentTime = dvrWindowSize;
+    // currentTime without shift should equal DVR window size
+    $(element).triggerHandler("durationchange");
+    params = vtc.notifyParameters[1];
+    expect(params.currentTime).to.be(dvrWindowSize);
+    // Seek to the middle of the stream
+    wrapper.seek(dvrWindowSize / 2);
+    $(element).triggerHandler("seeked");
+    // Time shift should be reflected in the value of currentTime
+    $(element).triggerHandler("durationchange");
+    params = vtc.notifyParameters[1];
+    expect(params.currentTime).to.be(dvrWindowSize / 2);
+  });
+
+  it('DVR: should update time shift after natively triggered SEEKED events', function() {
+    var params;
+    var dvrWindowSize = 1750;
+    enableDvr(0, dvrWindowSize);
+    $(element).triggerHandler("durationchange");
+    params = vtc.notifyParameters[1];
+    expect(params.currentTime).to.be(dvrWindowSize);
+    // Trigger seeked without calling wrapper.seek() in order to simulate native controls
+    element.currentTime = 875;
+    $(element).triggerHandler("seeked");
+    // Time shift should be reflected in the value of currentTime
+    $(element).triggerHandler("durationchange");
+    params = vtc.notifyParameters[1];
+    expect(params.currentTime).to.be(875);
+  });
+
+  it('DVR: should NOT update time shift after SEEKED events when seeking with wrapper.seek()', function() {
+    var params;
+    var dvrWindowSize = 1750;
+    var spy = enableDvr(0, dvrWindowSize);
+    element.currentTime = dvrWindowSize;
+    $(element).triggerHandler("durationchange");
+    params = vtc.notifyParameters[1];
+    expect(params.currentTime).to.be(dvrWindowSize);
+    // Time shift is updated when calling seek, but shouldn't be updated again when seeked is fired
+    wrapper.seek(dvrWindowSize / 2);
+    // Simulating that DVR window changes while we were seeking, which would result in a different shift value
+    spy.restore();
+    enableDvr(100, dvrWindowSize + 100);
+    $(element).triggerHandler("seeked");
+    // Current time should reflect shift calculated on wrapper.seeked() and shouldn't be updated after seeked event
+    $(element).triggerHandler("durationchange");
+    params = vtc.notifyParameters[1];
+    expect(params.currentTime).to.be(dvrWindowSize / 2);
+  });
+
+  it('DVR: should adapt to changes in the DVR window', function() {
+    var params;
+    var dvrWindowSize = 1750;
+    var midpoint = dvrWindowSize / 2;
+    var spy = enableDvr(0, dvrWindowSize);
+    element.currentTime = dvrWindowSize;
+    // Test seek with initial DVR window
+    wrapper.seek(midpoint);
+    $(element).triggerHandler("seeked");
+    $(element).triggerHandler("durationchange");
+    params = vtc.notifyParameters[1];
+    expect(params.currentTime).to.be(midpoint);
+    expect(Number(params.currentLiveTime)).to.be(midpoint);
+    // Move DVR window forward
+    spy.restore();
+    enableDvr(100, dvrWindowSize + 100);
+    // Test seek with updated DVR window
+    wrapper.seek(midpoint);
+    $(element).triggerHandler("seeked");
+    $(element).triggerHandler("durationchange");
+    params = vtc.notifyParameters[1];
+    expect(params.currentTime).to.be(midpoint);
+    expect(Number(params.currentLiveTime)).to.be(midpoint + 100);
   });
 
   it('should NOT ignore seek for VOD stream even if duration of video is zero or Infinity or NaN', function(){

--- a/tests/unit/main_html5/wrapper-event-tests.js
+++ b/tests/unit/main_html5/wrapper-event-tests.js
@@ -480,6 +480,7 @@ describe('main_html5 wrapper tests', function () {
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.DURATION_CHANGE,
       {
         "currentTime" : 3,
+        "currentLiveTime" : 0,
         "duration" : 10,
         "buffer" : 0,
         "seekRange" : {"start": 0, "end" : 0}
@@ -492,6 +493,7 @@ describe('main_html5 wrapper tests', function () {
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.DURATION_CHANGE,
       {
         "currentTime" : 3,
+        "currentLiveTime" : 0,
         "duration" : 10,
         "buffer" : 0,
         "seekRange" : {"start": 2, "end" : 10}
@@ -513,6 +515,7 @@ describe('main_html5 wrapper tests', function () {
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.DURATION_CHANGE,
       {
         "currentTime" : 3,
+        "currentLiveTime" : 0,
         "duration" : 10,
         "buffer" : 0,
         "seekRange" : {"start": 2, "end" : 10}
@@ -527,6 +530,7 @@ describe('main_html5 wrapper tests', function () {
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.DURATION_CHANGE,
       {
         "currentTime" : 3,
+        "currentLiveTime" : 0,
         "duration" : 10,
         "buffer" : 0,
         "seekRange" : {"start": 0, "end" : 0}
@@ -542,6 +546,7 @@ describe('main_html5 wrapper tests', function () {
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.DURATION_CHANGE,
       {
         "currentTime" : 3,
+        "currentLiveTime" : 0,
         "duration" : 10,
         "buffer" : 0,
         "seekRange" : {"start": 0, "end" : 0}
@@ -560,6 +565,7 @@ describe('main_html5 wrapper tests', function () {
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.DURATION_CHANGE,
       {
         "currentTime" : 3,
+        "currentLiveTime" : 0,
         "duration" : 10,
         "buffer" : 10,
         "seekRange" : {"start": 0, "end" : 10}
@@ -607,6 +613,7 @@ describe('main_html5 wrapper tests', function () {
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.TIME_UPDATE,
       {
         "currentTime" : 3,
+        "currentLiveTime" : 0,
         "duration" : 10,
         "buffer" : 0,
         "seekRange" : {"start": 0, "end" : 0}
@@ -625,6 +632,7 @@ describe('main_html5 wrapper tests', function () {
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.TIME_UPDATE,
       {
         "currentTime" : 3,
+        "currentLiveTime" : 0,
         "duration" : 10,
         "buffer" : 10,
         "seekRange" : {"start": 0, "end" : 10}
@@ -707,6 +715,7 @@ describe('main_html5 wrapper tests', function () {
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.TIME_UPDATE,
     {
         "currentTime" : 10,
+        "currentLiveTime" : 0,
         "duration" : 20,
         "buffer" : 0,
         "seekRange" : {"start": 0, "end" : 0}

--- a/tests/unit/main_html5/wrapper-event-tests.js
+++ b/tests/unit/main_html5/wrapper-event-tests.js
@@ -572,71 +572,6 @@ describe('main_html5 wrapper tests', function () {
       }]);
   });
 
-  it('should notify DURATION_CHANGE on video \'durationchange\' event with DVR-formatted values when playing DVR-enabled stream', function() {
-    var dvrWindowSize = 2000;
-    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS, true);
-    element.currentTime = dvrWindowSize;
-    element.duration = Infinity;
-    element.seekable.length = 1;
-    element.buffered.length = 1;
-    spyOn(element.seekable, "start").andReturn(0);
-    spyOn(element.seekable, "end").andReturn(dvrWindowSize);
-    spyOn(element.buffered, "end").andReturn(10);
-    $(element).triggerHandler("durationchange");
-    expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.DURATION_CHANGE, {
-      currentTime: dvrWindowSize,
-      currentLiveTime: element.currentTime,
-      duration: dvrWindowSize,
-      buffer: dvrWindowSize,
-      seekRange: { start: 0, end: dvrWindowSize }
-    }]);
-  });
-
-  it('should apply time shift to currentTime and report video.currentTime as currentLiveTime when notifying DURATION_CHANGE for DVR-enabled streams', function() {
-    var dvrWindowStart = 100;
-    var dvrWindowSize = 1400;
-    var dvrWindowEnd = dvrWindowStart + dvrWindowSize;
-    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS, true);
-    element.currentTime = dvrWindowEnd;
-    element.duration = Infinity;
-    element.seekable.length = 1;
-    element.buffered.length = 1;
-    spyOn(element.seekable, "start").andReturn(dvrWindowStart);
-    spyOn(element.seekable, "end").andReturn(dvrWindowEnd);
-    spyOn(element.buffered, "end").andReturn(10);
-    wrapper.seek(700);
-    $(element).triggerHandler("seeked");
-    $(element).triggerHandler("durationchange");
-    expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.DURATION_CHANGE, {
-      currentTime: 700,
-      currentLiveTime: element.currentTime,
-      duration: dvrWindowSize,
-      buffer: dvrWindowSize,
-      seekRange: {
-        start: dvrWindowStart,
-        end: dvrWindowEnd
-      }
-    }]);
-  });
-
-  it('should set duration and buffer to the size of the DVR window when notifying DURATION_CHANGE for DVR-enabled streams', function() {
-    var dvrWindowStart = 1000;
-    var dvrWindowSize = 1750;
-    var dvrWindowEnd = dvrWindowStart + dvrWindowSize;
-    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS, true);
-    element.currentTime = 2700;
-    element.duration = Infinity;
-    element.seekable.length = 1;
-    element.buffered.length = 1;
-    spyOn(element.seekable, "start").andReturn(dvrWindowStart);
-    spyOn(element.seekable, "end").andReturn(dvrWindowEnd);
-    spyOn(element.buffered, "end").andReturn(100);
-    $(element).triggerHandler("durationchange");
-    var params = vtc.notifyParameters[1];
-    expect(params.duration).to.be(dvrWindowSize);
-    expect(params.buffer).to.be(dvrWindowSize);
-  });
-
   it('should not raise durationChange before initial time is used', function(){
     OO.isAndroid = true;
     element.duration = 20;
@@ -785,6 +720,71 @@ describe('main_html5 wrapper tests', function () {
         "buffer" : 0,
         "seekRange" : {"start": 0, "end" : 0}
     }]);
+  });
+
+  it('DVR: should notify TIME_UPDATE on video \'timeupdate\' event with DVR-formatted values', function() {
+    var dvrWindowSize = 2000;
+    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS, true);
+    element.currentTime = dvrWindowSize;
+    element.duration = Infinity;
+    element.seekable.length = 1;
+    element.buffered.length = 1;
+    spyOn(element.seekable, "start").andReturn(0);
+    spyOn(element.seekable, "end").andReturn(dvrWindowSize);
+    spyOn(element.buffered, "end").andReturn(10);
+    $(element).triggerHandler("timeupdate");
+    expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.TIME_UPDATE, {
+      currentTime: dvrWindowSize,
+      currentLiveTime: element.currentTime,
+      duration: dvrWindowSize,
+      buffer: dvrWindowSize,
+      seekRange: { start: 0, end: dvrWindowSize }
+    }]);
+  });
+
+  it('DVR: should apply time shift to currentTime and report video.currentTime as currentLiveTime when notifying TIME_UPDATE', function() {
+    var dvrWindowStart = 100;
+    var dvrWindowSize = 1400;
+    var dvrWindowEnd = dvrWindowStart + dvrWindowSize;
+    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS, true);
+    element.currentTime = dvrWindowEnd;
+    element.duration = Infinity;
+    element.seekable.length = 1;
+    element.buffered.length = 1;
+    spyOn(element.seekable, "start").andReturn(dvrWindowStart);
+    spyOn(element.seekable, "end").andReturn(dvrWindowEnd);
+    spyOn(element.buffered, "end").andReturn(10);
+    wrapper.seek(700);
+    $(element).triggerHandler("seeked");
+    $(element).triggerHandler("timeupdate");
+    expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.TIME_UPDATE, {
+      currentTime: 700,
+      currentLiveTime: element.currentTime,
+      duration: dvrWindowSize,
+      buffer: dvrWindowSize,
+      seekRange: {
+        start: dvrWindowStart,
+        end: dvrWindowEnd
+      }
+    }]);
+  });
+
+  it('DVR: should set duration and buffer to the size of the DVR window when notifying TIME_UPDATE', function() {
+    var dvrWindowStart = 1000;
+    var dvrWindowSize = 1750;
+    var dvrWindowEnd = dvrWindowStart + dvrWindowSize;
+    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS, true);
+    element.currentTime = 2700;
+    element.duration = Infinity;
+    element.seekable.length = 1;
+    element.buffered.length = 1;
+    spyOn(element.seekable, "start").andReturn(dvrWindowStart);
+    spyOn(element.seekable, "end").andReturn(dvrWindowEnd);
+    spyOn(element.buffered, "end").andReturn(100);
+    $(element).triggerHandler("timeupdate");
+    var params = vtc.notifyParameters[1];
+    expect(params.duration).to.be(dvrWindowSize);
+    expect(params.buffer).to.be(dvrWindowSize);
   });
 
   // TODO: when async testing working, test for force end on timeupdate on m3u8


### PR DESCRIPTION
These changes will enable DVR functionality on browsers that can play HLS natively:

- Safari
- iOS  Safari
- MS Edge

Android Chrome doesn't support DVR yet, but if support is added later on these changes should work out of the box.