### PR TITLE
[PBW-6990] Workaround that allows manual playback when muted autoplay is not possible

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -495,6 +495,18 @@ require("../../../html5-common/js/utils/environment.js");
                 if (userInteractionRequired(error)) {
                   if (!_video.muted) {
                     this.controller.notify(this.controller.EVENTS.UNMUTED_PLAYBACK_FAILED, {error: error});
+                  } else {
+                    // [PBW-6990]
+                    // There seems to be an issue on random Android devices that prevents muted
+                    // autoplay from working at all under certain (currently unkown) conditions.
+                    // As a workaround for these cases, we raise a PLAYING event followed by a PAUSE
+                    // event in order to force the player out its initial loading state and allow manual
+                    // playback with the control bar.
+                    if (firstPlay && _video.paused) {
+                      OO.log("MainHtml5: Muted autoplay not possible, enabling controls for manual playback.");
+                      raisePlayingEvent();
+                      raisePauseEvent();
+                    }
                   }
                 }
               }

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -498,7 +498,7 @@ require("../../../html5-common/js/utils/environment.js");
                   } else {
                     // [PBW-6990]
                     // There seems to be an issue on random Android devices that prevents muted
-                    // autoplay from working at all under certain (currently unkown) conditions.
+                    // autoplay from working at all under certain (currently unknown) conditions.
                     // As a workaround for these cases, we raise a PLAYING event followed by a PAUSE
                     // event in order to force the player out its initial loading state and allow manual
                     // playback with the control bar.

--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -744,6 +744,31 @@ describe('main_html5 wrapper tests', function () {
     element.play = originalPlayFunction;
   });
 
+  it('should notify PLAYING followed by PAUSED when play promise fails and player detects that muted autoplay is not possible', function(){
+    var catchCallback = null;
+    var originalPlayFunction = element.play;
+    // Video muted successfully but playback still failed
+    element.muted = true;
+    element.paused = true;
+    // Replace mock play function with one that returns a promise
+    element.play = function() {
+      return {
+        then: function(callback) {
+        },
+        catch: function(callback) {
+          catchCallback = callback;
+        }
+      };
+    };
+    vtc.notified = [];
+    wrapper.play();
+    catchCallback({});
+    expect(vtc.notified[0]).to.eql(vtc.interface.EVENTS.PLAYING);
+    expect(vtc.notified[1]).to.eql(vtc.interface.EVENTS.PAUSED);
+    // Restore original play function
+    element.play = originalPlayFunction;
+  });
+
   it('should handle differing play promise failures', function(){
     //Chrome is a browser that throws different errors for play promise failures
     OO.isChrome = true;


### PR DESCRIPTION
[PBW-6990](https://jira.corp.ooyala.com/browse/PBW-6990)

It looks like there's a random Android bug that causes muted autoplay to fail in general even with [Chrome's muted autoplay samples](https://googlechrome.github.io/samples/muted-autoplay/). 

This workaround will basically fire the `PLAYING` and `PAUSED` events in order to force the player out its initial loading state and show the control bar so that the user can resume manually. A cleaner approach might be to set the player back to its initial state, however, we don't have any logic to reset the player without changing the embed code yet, so this would be more complicated and risky.

If we're ok with this approach we will need to implement something similar for BitWrapper as well.