### PR TITLE
[PLAYER-3129] Workaround for .swf files not being found when using Valhalla

### DIFF
--- a/src/akamai/js/akamaiHD_flash.js
+++ b/src/akamai/js/akamaiHD_flash.js
@@ -27,8 +27,11 @@ require("../../../html5-common/js/utils/constants.js");
     }
   }
   if (!pluginPath) {
-    console.error("Can't get path to script", filename);
-    return;
+    // [PLAYER-3129]
+    // It's safe to hard-code the path to this file since this plugin isn't
+    // being developed further. The .swf file shouldn't change anymore.
+    console.log("[AkamaiHD]: Failed to determine .swf file path, will use default.");
+    pluginPath = "//player.ooyala.com/static/v4/production/video-plugin/";
   }
   pluginPath += "akamaiHD_flash.swf";
   var flexPath = "playerProductInstall.swf";
@@ -228,7 +231,7 @@ require("../../../html5-common/js/utils/constants.js");
      * @method OoyalaAkamaiHDFlashVideoWrapper#setVideoUrl
      * @param {string} url The new url to insert into the video element's src attribute
      * @param {string} encoding The encoding of video stream
-     * @param {string} isLive Notifies whether the stream is live (unused here). 
+     * @param {string} isLive Notifies whether the stream is live (unused here).
      * @returns {boolean} True or false indicating success
      */
     this.setVideoUrl = function(url, encoding) {
@@ -265,7 +268,7 @@ require("../../../html5-common/js/utils/constants.js");
      * @param {object} contentMetadata The object with the content metadata info.
      */
     this.setSecureContent = function(contentMetadata)
-    {      
+    {
       this.callToFlash("setSecureContent()", contentMetadata);
     };
 
@@ -455,7 +458,7 @@ require("../../../html5-common/js/utils/constants.js");
 
     // Calls a Flash method
     this.callToFlash = function (data,dataObj) {
-      if(videoItem == undefined) { 
+      if(videoItem == undefined) {
         javascriptCommandQueue.push([data,dataObj]);
       } else {
         if (videoItem.sendToActionScript) {
@@ -1567,4 +1570,3 @@ var swfobject = function() {
     }
   };
 }();
-

--- a/src/osmf/js/osmf_flash.js
+++ b/src/osmf/js/osmf_flash.js
@@ -27,8 +27,11 @@ require("../../../html5-common/js/utils/constants.js");
     }
   }
   if (!pluginPath) {
-    console.error("Can't get path to script", filename);
-    return;
+    // [PLAYER-3129]
+    // It's safe to hard-code the path to this file since this plugin isn't
+    // being developed further. The .swf file shouldn't change anymore.
+    console.log("[OSMF]: Failed to determine .swf file path, will use default.");
+    pluginPath = "//player.ooyala.com/static/v4/production/video-plugin/";
   }
   pluginPath += "osmf_flash.swf";
   var flexPath = "playerProductInstall.swf";
@@ -281,7 +284,7 @@ require("../../../html5-common/js/utils/constants.js");
      * @method OoyalaFlashVideoWrapper#setVideoUrl
      * @param {string} url The new url to insert into the video element's src attribute
      * @param {string} encoding The encoding of video stream
-     * @param {boolean} isLive Notifies whether the stream is live. 
+     * @param {boolean} isLive Notifies whether the stream is live.
      * @returns {boolean} True or false indicating success
      */
     this.setVideoUrl = function(url, encoding, isLive) {
@@ -499,7 +502,7 @@ require("../../../html5-common/js/utils/constants.js");
 
     // Calls a Flash method
     this.callToFlash = function (data,dataObj) {
-      if(_video == undefined) { 
+      if(_video == undefined) {
         javascriptCommandQueue.push([data,dataObj]);
       } else {
         if (_video.sendToActionScript) {
@@ -687,7 +690,7 @@ require("../../../html5-common/js/utils/constants.js");
         OO.log('[OSMF]:JFlashBridge: Call: ', arguments);
 
         var klass = flashItems[arguments[0]];
-  
+
         if (klass) {
           klass.onCallback(arguments[2]);
         }
@@ -1594,4 +1597,3 @@ var swfobject = function() {
     }
   };
 }();
-


### PR DESCRIPTION
Super simple workaround that hard codes the path to the .swf file (for OSMF and Akamai plugins) when it can't be obtained from the script tag. The reasoning is that we're no longer updating these plugins so it's safe to use a static file location.

These plugins don't have unit tests.