### PR TITLE
[player-3192]

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -292,11 +292,10 @@ require("../../../html5-common/js/utils/environment.js");
       // suspend, abort, emptied, loadeddata, resize, change, addtrack, removetrack
       _.each(listeners, function(v, i) { $(_video).on(i, v); }, this);
       // The volumechange event does not seem to fire for mute state changes when using jQuery
-      // to add the event listener or when using addEventListener("volumechange"). It does
-      // work using the below line. We need this event to fire properly or else other SDKs
-      // (such as the Freewheel ad SDK) that make use of this video element may have issues with
-      // the mute state
-      _video.onvolumechange = raiseVolumeEvent;
+      // to add the event listener. It does work using the below line. We need this event to fire properly
+      // or else other SDKs (such as the Freewheel ad SDK) that make use of this video element may have
+      // issues with the mute state
+      _video.addEventListener('volumechange', raiseVolumeEvent);
     };
 
     /**
@@ -307,6 +306,7 @@ require("../../../html5-common/js/utils/environment.js");
      */
     var unsubscribeAllEvents = function() {
       _.each(listeners, function(v, i) { $(_video).off(i, v); }, this);
+      _video.removeEventListener('volumechange', raiseVolumeEvent);
     };
 
     /**

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -284,8 +284,6 @@ require("../../../html5-common/js/utils/environment.js");
                     "play": raisePlayEvent,
                     "pause": raisePauseEvent,
                     "ratechange": raiseRatechangeEvent,
-                    "volumechange": raiseVolumeEvent,
-                    "volumechangeNew": raiseVolumeEvent,
                         // ios webkit browser fullscreen events
                     "webkitbeginfullscreen": raiseFullScreenBegin,
                     "webkitendfullscreen": raiseFullScreenEnd
@@ -293,6 +291,12 @@ require("../../../html5-common/js/utils/environment.js");
       // events not used:
       // suspend, abort, emptied, loadeddata, resize, change, addtrack, removetrack
       _.each(listeners, function(v, i) { $(_video).on(i, v); }, this);
+      // The volumechange event does not seem to fire for mute state changes when using jQuery
+      // to add the event listener or when using addEventListener("volumechange"). It does
+      // work using the below line. We need this event to fire properly or else other SDKs
+      // (such as the Freewheel ad SDK) that make use of this video element may have issues with
+      // the mute state
+      _video.onvolumechange = raiseVolumeEvent;
     };
 
     /**
@@ -569,11 +573,6 @@ require("../../../html5-common/js/utils/environment.js");
      */
     this.mute = function() {
       _video.muted = true;
-
-      //the volumechange event is supposed to be fired when video.muted is changed,
-      //but it doesn't always fire. Raising a volume event here with the current volume
-      //to cover these situations
-      raiseVolumeEvent({ target: { volume: _video.volume }});
     };
 
     /**
@@ -591,11 +590,6 @@ require("../../../html5-common/js/utils/environment.js");
       if (currentVolumeSet > 0) {
         this.setVolume(currentVolumeSet);
       }
-
-      //the volumechange event is supposed to be fired when video.muted is changed,
-      //but it doesn't always fire. Raising a volume event here with the current volume
-      //to cover these situations
-      raiseVolumeEvent({ target: { volume: _video.volume }});
     };
 
     /**

--- a/tests/unit/main_html5/wrapper-event-tests.js
+++ b/tests/unit/main_html5/wrapper-event-tests.js
@@ -873,15 +873,6 @@ describe('main_html5 wrapper tests', function () {
   //  expect(vtc.notifyParametersHistory[1]).to.eql([vtc.interface.EVENTS.MUTE_STATE_CHANGE, { muted: true }]);
   //});
 
-  it('should notify VOLUME_CHANGE on video \'volumechangeNew\' event', function(){
-    vtc.notifyParametersHistory = [];
-    $(element).triggerHandler({
-      type: "volumechangeNew",
-      target: {volume: 0.3}
-    });
-    expect(vtc.notifyParametersHistory[0]).to.eql([vtc.interface.EVENTS.VOLUME_CHANGE, { volume: 0.3 }]);
-  });
-
   it('should notify VOLUME_CHANGE on setting video volume', function(){
     vtc.notifyParametersHistory = [];
     element.volume = 0.3;


### PR DESCRIPTION
-we will now use onvolumechange to listen for volume/mute state changes with main_html5. This allows us to maintain a more accurate state for us and external SDKs such as Freewheel
-removed volumechangeNew as it was not in use and is not a real event