### PR TITLE
Feature/player 2945

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -900,7 +900,10 @@ require("../../../html5-common/js/utils/environment.js");
           }
         }
       }
-      raiseAudioChange(audioTracks);
+      // audioTracks right now is Array-like, not actually an array
+      // so we need to make it so
+      var newTracks = this.getAvailableAudio();
+      raiseAudioChange(newTracks);
     };
 
     // **********************************************************************************/

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -907,6 +907,7 @@ require("../../../html5-common/js/utils/environment.js");
           }
         }
       }
+      raiseAudioChange(audioTracks);
     };
 
     // **********************************************************************************/
@@ -952,17 +953,27 @@ require("../../../html5-common/js/utils/environment.js");
      * Fired when there's a change on audioTracks
      * @private
      * @method OoyalaVideoFactory#onAudioChange
-     * @fires VideoController#EVENTS.MULTI_AUDIO_AVAILABLE
+     * @fires VideoController#EVENTS.MULTI_AUDIO_CHANGE
      */
     var _onAudioChange = _.bind(function(event) {
       var audioTracks = this.getAvailableAudio();
-
+      raiseAudioChange(audioTracks);
+    }, this);
+    
+    /**
+     * Raised notification to VideoController
+     * @private
+     * @method OoyalaVideoFactory#onAudioChange
+     * @fires VideoController#EVENTS.MULTI_AUDIO_CHANGE
+     */
+    var raiseAudioChange = _.bind(function(audioTracks) {
+      // the problem here is that onchange gets triggered twice so
+      // we compare old this.audioTracks with new audioTracks
+      // to get updated tracks just once
       if (!_.isEqual(this.audioTracks, audioTracks)) {
-        this.audioTracks = this.getAvailableAudio();
-        console.log('CHANGE IN TRACKS -> ', this.audioTracks);
+        this.audioTracks = audioTracks;
+        this.controller.notify(this.controller.EVENTS.MULTI_AUDIO_CHANGED, audioTracks);
       } 
-
-      this.controller.notify(this.controller.EVENTS.MULTI_AUDIO_CHANGED, audioTracks);
     }, this);
 
     /**

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -888,18 +888,22 @@ require("../../../html5-common/js/utils/environment.js");
         var currentAudio = _.find(audioTracks, function (track) {
           return track.enabled;
         });
-        var currentAudioId = currentAudio.id;
-        if (currentAudioId !== trackId) {
-          var newAudioTrack = audioTracks.getTrackById(trackId);
-          if (newAudioTrack) { // if trackId is correct and the audio exists
-            var prevAudioTrack = audioTracks.getTrackById(currentAudioId);
-            if (prevAudioTrack) { // if currentAudioId is correct and the audio exists
-              prevAudioTrack.enabled = false; // the audio is not active anymore
+        var currentAudioId = null;
+        if (currentAudio && currentAudio.id) {
+          currentAudioId = currentAudio.id;
+          if (currentAudioId !== trackId) {
+            var newAudioTrack = audioTracks.getTrackById(trackId);
+            if (newAudioTrack) { // if trackId is correct and the audio exists
+              var prevAudioTrack = audioTracks.getTrackById(currentAudioId);
+              if (prevAudioTrack) { // if currentAudioId is correct and the audio exists
+                prevAudioTrack.enabled = false; // the audio is not active anymore
+              }
+              newAudioTrack.enabled = true; // the audio is active
             }
-            newAudioTrack.enabled = true; // the audio is active
           }
         }
       }
+      
       // audioTracks right now is Array-like, not actually an array
       // so we need to make it so
       var newTracks = this.getAvailableAudio();

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -853,7 +853,7 @@ require("../../../html5-common/js/utils/environment.js");
     /**
      * For multi audio we can get a list of available audio tracks
      * @public
-     * method OoyalaVideoWrapper#getAvailableAudio
+     * @method OoyalaVideoWrapper#getAvailableAudio
      * @returns {Array} - an array of all available audio tracks.
      */
     this.getAvailableAudio = function() {
@@ -880,29 +880,22 @@ require("../../../html5-common/js/utils/environment.js");
      * @public
      * @method OoyalaVideoWrapper#setAudio
      * @param {String} trackId - the ID of the audio track to activate
-     * @returns {array} - list of available audio streams
+     * @callback OoyalaVideoFactory#raiseAudioChange
      */
     this.setAudio = function(trackId) {
       var audioTracks = _video.audioTracks;
-      
       if (audioTracks && audioTracks.length) { // if audioTracks exist
-        
         var currentAudio = _.find(audioTracks, function (track) {
           return track.enabled;
         });
-
         var currentAudioId = currentAudio.id;
-
         if (currentAudioId !== trackId) {
           var newAudioTrack = audioTracks.getTrackById(trackId);
-          
           if (newAudioTrack) { // if trackId is correct and the audio exists
             var prevAudioTrack = audioTracks.getTrackById(currentAudioId);
-            
             if (prevAudioTrack) { // if currentAudioId is correct and the audio exists
               prevAudioTrack.enabled = false; // the audio is not active anymore
             }
-
             newAudioTrack.enabled = true; // the audio is active
           }
         }
@@ -953,7 +946,7 @@ require("../../../html5-common/js/utils/environment.js");
      * Fired when there's a change on audioTracks
      * @private
      * @method OoyalaVideoFactory#onAudioChange
-     * @fires VideoController#EVENTS.MULTI_AUDIO_CHANGE
+     * @callback OoyalaVideoFactory#raiseAudioChange
      */
     var _onAudioChange = _.bind(function(event) {
       var audioTracks = this.getAvailableAudio();

--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -1140,21 +1140,11 @@ describe('main_html5 wrapper tests', function () {
       {id: "0", kind: "main", label: "eng", language: "eng", enabled: false},
       {id: "1", kind: "main", label: "ger", language: "ger", enabled: true}
     ]);
-
-    expect(element.audioTracks).to.eql([
-      {id: "0", kind: "main", label: "eng", language: "eng", enabled: false},
-      {id: "1", kind: "main", label: "ger", language: "ger", enabled: true}
-    ]);
-
+    
     //pass wrong id
     var resWithWrongId = wrapper.setAudio("6789");
 
     expect(audioTracks).to.eql([
-      {id: "0", kind: "main", label: "eng", language: "eng", enabled: false},
-      {id: "1", kind: "main", label: "ger", language: "ger", enabled: true}
-    ]);
-
-    expect(element.audioTracks).to.eql([
       {id: "0", kind: "main", label: "eng", language: "eng", enabled: false},
       {id: "1", kind: "main", label: "ger", language: "ger", enabled: true}
     ]);

--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -1127,18 +1127,20 @@ describe('main_html5 wrapper tests', function () {
     ]);
   });
 
-  it('setAudio should set the audio by id and return array with audio objects', function(){
+  it('setAudio should set the audio by id', function(){
     wrapper.currentAudioId = "0";
     element.audioTracks = audioTracks;
     element.audioTracks.__proto__ = {
       getTrackById: vtc.getTrackById
     };
-    //pass correct id
+    // pass correct id
     var resWithCorrectId = wrapper.setAudio("1");
-    expect(resWithCorrectId).to.eql([
-      {id: "0", label: "eng", lang: "eng", enabled: false},
-      {id: "1", label: "ger", lang: "ger", enabled: true}
+
+    expect(audioTracks).to.eql([
+      {id: "0", kind: "main", label: "eng", language: "eng", enabled: false},
+      {id: "1", kind: "main", label: "ger", language: "ger", enabled: true}
     ]);
+
     expect(element.audioTracks).to.eql([
       {id: "0", kind: "main", label: "eng", language: "eng", enabled: false},
       {id: "1", kind: "main", label: "ger", language: "ger", enabled: true}
@@ -1146,10 +1148,12 @@ describe('main_html5 wrapper tests', function () {
 
     //pass wrong id
     var resWithWrongId = wrapper.setAudio("6789");
-    expect(resWithWrongId).to.eql([
-      {id: "0", label: "eng", lang: "eng", enabled: false},
-      {id: "1", label: "ger", lang: "ger", enabled: true}
+
+    expect(audioTracks).to.eql([
+      {id: "0", kind: "main", label: "eng", language: "eng", enabled: false},
+      {id: "1", kind: "main", label: "ger", language: "ger", enabled: true}
     ]);
+
     expect(element.audioTracks).to.eql([
       {id: "0", kind: "main", label: "eng", language: "eng", enabled: false},
       {id: "1", kind: "main", label: "ger", language: "ger", enabled: true}

--- a/tests/unit/main_html5/wrapper-event-tests.js
+++ b/tests/unit/main_html5/wrapper-event-tests.js
@@ -189,9 +189,19 @@ describe('main_html5 wrapper tests', function () {
 
   it('should notify MULTI_AUDIO_AVAILABLE on first \'canPlay\' event', function(){
     wrapper.getAvailableAudio = function() {
-      return [{"id": 1}, {"id": 2}];
+      return [{
+        "id": 1,
+        "label": "eng",
+        "lang": "eng",
+        "enabled": true
+      }, {
+        "id": 2,
+        "label": "ger",
+        "lang": "ger",
+        enabled: false
+      }];
     };
-    $(element).triggerHandler("canplay");
+    $(element).triggerHandler('canplay');
     expect(vtc.notifyParameters[0]).to.eql(vtc.interface.EVENTS.MULTI_AUDIO_AVAILABLE);
   });
 
@@ -201,6 +211,33 @@ describe('main_html5 wrapper tests', function () {
     };
     $(element).triggerHandler("canplay");
     expect(vtc.notifyParameters[0]).to.not.eql(vtc.interface.EVENTS.MULTI_AUDIO_AVAILABLE);
+  });
+
+  it('should notify MULTI_AUDIO_CHANGED after setAudio', function() {
+    element.audioTracks[0] = { id: 0, language: 'en', label: '', enabled: true };
+    element.audioTracks[1] = { id: 1, language: 'en', label: '', enabled: false };
+    
+    element.audioTracks.__proto__ = {
+      getTrackById: vtc.getTrackById
+    };
+
+    wrapper.setAudio(1);
+    wrapper.setAudio(1);
+    wrapper.setAudio(1);
+    wrapper.setAudio(1);
+    wrapper.setAudio(1);
+    wrapper.setAudio(1);
+    wrapper.setAudio(1);
+    wrapper.setAudio(1);
+    wrapper.setAudio(1);
+
+    var callCount = vtc.notified.reduce(function (accumulator, event) {
+      return event === vtc.interface.EVENTS.MULTI_AUDIO_CHANGED ? 
+        accumulator = accumulator + 1 :
+        accumulator;
+    }, 0);
+
+    expect(callCount).to.be(1);
   });
 
   it('should notify CAPTIONS_FOUND_ON_PLAYING on first video \'playing\' event if video has cc', function(){

--- a/tests/unit/main_html5/wrapper-event-tests.js
+++ b/tests/unit/main_html5/wrapper-event-tests.js
@@ -190,14 +190,14 @@ describe('main_html5 wrapper tests', function () {
   it('should notify MULTI_AUDIO_AVAILABLE on first \'canPlay\' event', function(){
     wrapper.getAvailableAudio = function() {
       return [{
-        "id": 1,
-        "label": "eng",
-        "lang": "eng",
-        "enabled": true
+        'id': 1,
+        'label': 'eng',
+        'lang': 'eng',
+        'enabled': true
       }, {
-        "id": 2,
-        "label": "ger",
-        "lang": "ger",
+        'id': 2,
+        'label': 'ger',
+        'lang': 'ger',
         enabled: false
       }];
     };
@@ -207,9 +207,9 @@ describe('main_html5 wrapper tests', function () {
 
   it('should not notify MULTI_AUDIO_AVAILABLE on first \'canPlay\' event when getAvailableAudio returns too short array', function(){
     wrapper.getAvailableAudio = function() {
-      return [{"id": 1}];
+      return [{'id': 1}];
     };
-    $(element).triggerHandler("canplay");
+    $(element).triggerHandler('canplay');
     expect(vtc.notifyParameters[0]).to.not.eql(vtc.interface.EVENTS.MULTI_AUDIO_AVAILABLE);
   });
 

--- a/tests/utils/mock_vtc.js
+++ b/tests/utils/mock_vtc.js
@@ -33,7 +33,8 @@ mock_vtc = function() {
       UNMUTED_PLAYBACK_FAILED: "unmutedPlaybackFailed",
       UNMUTED_PLAYBACK_SUCCEEDED: "unmutedPlaybackSucceeded",
       MUTED_PLAYBACK_FAILED: "unmutedPlaybackFailed",
-      MULTI_AUDIO_AVAILABLE: "multiAudioAvailable"
+      MULTI_AUDIO_AVAILABLE: "multiAudioAvailable",
+      MULTI_AUDIO_CHANGED: "multiAudioChanged"
     },
     notify: function(){
       if (arguments.length > 0) {


### PR DESCRIPTION
This PR introduces is an improvement for track change flow. 
It introduces more clear approach to changing active tracks by adding new event - `MULTI_AUDIO_CHANGED`.

### Addresses
[PLAYER-3197](https://jira.corp.ooyala.com:8443/projects/PLAYER/issues/PLAYER-3197)
[PLAYER-3191](https://jira.corp.ooyala.com:8443/projects/PLAYER/issues/PLAYER-3191)
[PLAYER-2945](https://jira.corp.ooyala.com:8443/browse/PLAYER-2945)
[PLAYER-3123](https://jira.corp.ooyala.com:8443/browse/PLAYER-3123)

### Related PRs

[#1043](https://github.com/ooyala/html5-skin/pull/1043)
[#449](https://git.corp.ooyala.com/projects/PBW/repos/mjolnir/pull-requests/449/overview)

### Summary of changes
main_html5
- rework logic for setting active audio track
- add listener to onchange event

### Tests
main_html5
- verify that tracks get changed 
- verify that only 1 event gets fired for every subsequent change
- [x] All Unit tests passed without errors

### Misc
Codestyle changes
