### PR TITLE
[player-3601]

### DIFF
--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -169,11 +169,19 @@ describe('main_html5 wrapper tests', function () {
     expect(returns).to.be(true);
   });
 
-  it('should remove src on empty string', function(){
+  it('should null out src on empty string', function(){
     wrapper.setVideoUrl("url");
     var returns = wrapper.setVideoUrl("", "");
     expect(returns).to.be(true);
     expect(element.getAttribute("src")).to.eql(null);
+  });
+
+  it('should remove src on empty string on iOS', function(){
+    OO.isIos = true;
+    wrapper.setVideoUrl("url");
+    var returns = wrapper.setVideoUrl("", "");
+    expect(returns).to.be(true);
+    expect(typeof element.src).to.eql("undefined");
   });
 
   it('should call stream load', function(){


### PR DESCRIPTION
-fixed an issue where we get play promise errors when we clear out video srcs on iOS
-workaround of an issue where FW sometimes throws non-fatal play promise errors on iOS that we can ignore