### PR TITLE
bugfix/PLAYER-4001 Issue when contols are auto hidden when player paused in iOS

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -1506,7 +1506,20 @@ require("../../../html5-common/js/utils/environment.js");
         this.controller.notify(this.controller.EVENTS.PAUSED);
       }
       forceEndOnPausedIfRequired();
+      removeControlsAttr();
     }, this);
+
+    /**
+     * IOS native player adds attribute "controls" to video tag.
+     * This function removes the attribute on IOS if it is necessary
+     * @private
+     * @method OoyalaVideoWrapper#removeControlsAttr
+     */
+    var removeControlsAttr = _.bind(function(){
+      if (OO.isIos && _video.hasAttribute('controls')) {
+        _video.removeAttribute('controls');
+      }
+    });
 
     /**
      * Notifies the controller that the ratechange event was raised.

--- a/tests/unit/main_html5/underflow-tests.js
+++ b/tests/unit/main_html5/underflow-tests.js
@@ -141,6 +141,20 @@ describe('main_html5 chrome underflow tests', function () {
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.WAITING, { url : "url" }]);
   });
 
+  it('Should remove attr "controls" on IOS when pause event was fired', function(){
+    OO.isIos = true;
+    element.setAttribute("controls", "controls");
+    expect(element.getAttribute("controls")).to.eql("controls");
+    $(element).triggerHandler("pause");
+    expect(element.getAttribute("controls")).to.eql(null);
+
+    OO.isIos = false;
+    element.setAttribute("controls", "controls");
+    expect(element.getAttribute("controls")).to.eql("controls");
+    $(element).triggerHandler("pause");
+    expect(element.getAttribute("controls")).to.eql("controls");
+  });
+
   it('should not raise waiting event once the stream has ended', function(){
     vtc.interface.EVENTS.WAITING = "waiting";
     vtc.interface.EVENTS.PLAYING = "playing";


### PR DESCRIPTION
Attribute "controls" is automatically added by the iOS. The attribute is not deleted, when we clicking not on a cross icon, but swiping to exit.
A function "removeControlsAttr" was added to the main_html5. The function forced delets the attribute. We call the function in function "raisePauseEvent", which is called each time we exit the fullscreen mode.

[The origin task](https://jira.corp.ooyala.com:8443/browse/PLAYER-4001)

Unit tests are passed.