### PR TITLE
[PLAYER-4150] Allowing multiple in-manifest/in-stream captions

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -1151,11 +1151,11 @@ require("../../../html5-common/js/utils/environment.js");
           // For in-manifest/in-stream captions we use the id of the track (e.g.
           // CC1, CC2, etc.) as a language in order to avoid conflicts with
           // external captions.
-          var language = trySetStreamTextTrackId(currentTrack);
+          var trackId = trySetStreamTextTrackId(currentTrack);
           var captionInfo = {
-            language: language,
+            language: trackId,
             inStream: true,
-            label: currentTrack.label || language
+            label: currentTrack.label || currentTrack.language || trackId
           };
           // Don't overwrite other closed captions of this language. They have priority.
           if (!availableClosedCaptions[captionInfo.language]) {

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -1156,7 +1156,7 @@ require("../../../html5-common/js/utils/environment.js");
           var captionInfo = {
             language: trackId,
             inStream: true,
-            label: currentTrack.label || currentTrack.language || trackId
+            label: currentTrack.label || currentTrack.language || 'Captions (' + trackId + ')'
           };
           // Don't overwrite other closed captions of this language. They have priority.
           if (!availableClosedCaptions[captionInfo.language]) {

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -804,6 +804,7 @@ require("../../../html5-common/js/utils/environment.js");
               _video.textTracks[i].oncuechange = onClosedCaptionCueChange;
             } else {
               _video.textTracks[i].mode = OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED;
+              _video.textTracks[i].oncuechange = null;
             }
             // [PLAYER-327], [PLAYER-73]
             // We keep track of all text track modes in order to prevent Safari from randomly

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -1199,7 +1199,7 @@ require("../../../html5-common/js/utils/environment.js");
 
     /**
      * Tries to set a custom id on a in-manifest/in-stream TextTrack object which
-     * allows us to identify it for selection and workaround purposes. Id's set are
+     * allows us to identify it for selection and workaround purposes. IDs set are
      * stored on a custom trackId property and are of the type 'CCn', where n is the
      * index of the track relative to the order in which it was found. Existing track
      * ids will not be overriten.

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -1170,10 +1170,11 @@ require("../../../html5-common/js/utils/environment.js");
           // CC1, CC2, etc.) as a language in order to avoid conflicts with
           // external captions.
           var trackId = trySetStreamTextTrackId(currentTrack);
+          var label = currentTrack.label || currentTrack.language || 'Captions (' + trackId + ')';
           var captionInfo = {
             language: trackId,
             inStream: true,
-            label: currentTrack.label || currentTrack.language || 'Captions (' + trackId + ')'
+            label: label
           };
           // Don't overwrite other closed captions of this language. They have priority.
           if (!availableClosedCaptions[captionInfo.language]) {
@@ -1206,7 +1207,7 @@ require("../../../html5-common/js/utils/environment.js");
      * @private
      * @method OoyalaVideoWrapper#trySetStreamTextTrackId
      * @param {TextTrack} textTrack The TextTrack object whose id we want to set.
-     * @return {String} The new or pre-existing id of the track
+     * @return {String} The new or pre-existing id of the track, null if textTrack is invalid
      */
     var trySetStreamTextTrackId = _.bind(function(textTrack) {
       if (!textTrack) {

--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -1211,6 +1211,60 @@ describe('main_html5 wrapper tests', function () {
     expect(element.textTracks[1].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.HIDDEN);
   });
 
+  it('should only enable the in-manifest/in-stream track that matches language parameter', function() {
+    var isLive = true;
+    OO.isSafari = true;
+    element.textTracks = [
+      { language: "", label: "", kind: "subtitles" },
+      { language: "", label: "", kind: "subtitles" },
+      { language: "", label: "", kind: "subtitles" }
+    ];
+    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS, isLive);
+    $(element).triggerHandler("playing");
+    wrapper.setClosedCaptions("CC3", null, { mode: OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING });
+    expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
+    expect(element.textTracks[1].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
+    expect(element.textTracks[2].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING);
+  });
+
+  it('should set custom ids on in-manifest/in-stream tracks when stream tracks are checked', function() {
+    var isLive = true;
+    OO.isSafari = true;
+    element.textTracks = [
+      { language: "", label: "", kind: "subtitles" },
+      { language: "", label: "", kind: "subtitles" },
+      { language: "", label: "", kind: "subtitles" },
+      { language: "", label: "", kind: "subtitles" }
+    ];
+    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS, isLive);
+    $(element).triggerHandler("playing");
+    expect(element.textTracks[0].trackId).to.eql('CC1');
+    expect(element.textTracks[1].trackId).to.eql('CC2');
+    expect(element.textTracks[2].trackId).to.eql('CC3');
+    expect(element.textTracks[3].trackId).to.eql('CC4');
+  });
+
+  it('should set custom ids on in-manifest/in-stream tracks when closed captions are set if ids haven\'t been added yet', function() {
+    var isLive = true;
+    OO.isSafari = true;
+    element.textTracks = [
+      { language: "", label: "", kind: "subtitles" },
+      { language: "", label: "", kind: "subtitles" }
+    ];
+    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS, isLive);
+    $(element).triggerHandler("playing");
+    expect(element.textTracks[0].trackId).to.eql('CC1');
+    expect(element.textTracks[1].trackId).to.eql('CC2');
+    // Add some new tracks
+    element.textTracks.push({ language: "", label: "", kind: "subtitles" });
+    element.textTracks.push({ language: "", label: "", kind: "subtitles" });
+    wrapper.setClosedCaptions("CC2", null, { mode: OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING });
+    expect(element.textTracks[0].trackId).to.eql('CC1');
+    expect(element.textTracks[1].trackId).to.eql('CC2');
+    expect(element.textTracks[2].trackId).to.eql('CC3');
+    expect(element.textTracks[3].trackId).to.eql('CC4');
+  });
+
   it('should remove closed captions if language is null', function(){
     wrapper.setClosedCaptions(language, closedCaptions, params);
     expect(element.children.length > 0).to.be(true);

--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -1141,7 +1141,7 @@ describe('main_html5 wrapper tests', function () {
     element.textTracks = [{ mode: OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED, kind: "captions" }];
     $(element).triggerHandler("playing");
     expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
-    wrapper.setClosedCaptions("CC", null, { mode: "showing" });
+    wrapper.setClosedCaptions("CC1", null, { mode: "showing" });
     expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING);
   });
 
@@ -1198,8 +1198,12 @@ describe('main_html5 wrapper tests', function () {
     expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
     expect(element.textTracks[1].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
 
-    wrapper.setClosedCaptions("CC", null, {mode: OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING});
+    wrapper.setClosedCaptions("CC1", null, {mode: OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING});
     expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING);
+    expect(element.textTracks[1].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
+
+    wrapper.setClosedCaptions("CC2", null, {mode: OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING});
+    expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
     expect(element.textTracks[1].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING);
 
     wrapper.setClosedCaptions("en", closedCaptions, {mode: OO.CONSTANTS.CLOSED_CAPTIONS.HIDDEN}); // this adds external captions

--- a/tests/unit/main_html5/wrapper-event-tests.js
+++ b/tests/unit/main_html5/wrapper-event-tests.js
@@ -423,7 +423,7 @@ describe('main_html5 wrapper tests', function () {
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.CAPTIONS_FOUND_ON_PLAYING, {
       languages: ['CC1'],
       locale: {
-        CC1: 'CC1'
+        CC1: 'Captions (CC1)'
       }
     }]);
   });
@@ -438,7 +438,7 @@ describe('main_html5 wrapper tests', function () {
       languages: ['en', 'CC1'],
       locale: {
         en: 'English',
-        CC1: 'CC1'
+        CC1: 'Captions (CC1)'
       }
     }]);
   });
@@ -450,7 +450,7 @@ describe('main_html5 wrapper tests', function () {
     $(element).triggerHandler("playing"); // this adds in-stream captions
 
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.CAPTIONS_FOUND_ON_PLAYING, {
-      languages: ['CC1'], locale: { CC1: 'CC1' }}]);
+      languages: ['CC1'], locale: { CC1: 'Captions (CC1)' }}]);
   });
 
   it('should notify CAPTIONS_FOUND_ON_PLAYING with multiple in-manifest/in-stream captions', function() {
@@ -468,9 +468,9 @@ describe('main_html5 wrapper tests', function () {
       languages: ['en', 'CC1', 'CC2', 'CC3'],
       locale: {
         en: 'English',
-        CC1: 'CC1',
-        CC2: 'CC2',
-        CC3: 'CC3'
+        CC1: 'Captions (CC1)',
+        CC2: 'Captions (CC2)',
+        CC3: 'Captions (CC3)'
       }
     }]);
   });
@@ -490,7 +490,7 @@ describe('main_html5 wrapper tests', function () {
       languages: ['en', 'CC1', 'CC2', 'CC3'],
       locale: {
         en: 'English',
-        CC1: 'CC1',
+        CC1: 'Captions (CC1)',
         CC2: 'es',
         CC3: 'German'
       }
@@ -509,8 +509,8 @@ describe('main_html5 wrapper tests', function () {
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.CAPTIONS_FOUND_ON_PLAYING, {
       languages: ['CC1', 'CC2'],
       locale: {
-        CC1: 'CC1',
-        CC2: 'CC2',
+        CC1: 'Captions (CC1)',
+        CC2: 'Captions (CC2)',
       }
     }]);
     // Tracks should start from 1 once more instead of CC3, CC4...
@@ -523,8 +523,8 @@ describe('main_html5 wrapper tests', function () {
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.CAPTIONS_FOUND_ON_PLAYING, {
       languages: ['CC1', 'CC2'],
       locale: {
-        CC1: 'CC1',
-        CC2: 'CC2',
+        CC1: 'Captions (CC1)',
+        CC2: 'Captions (CC2)',
       }
     }]);
   });

--- a/tests/unit/main_html5/wrapper-event-tests.js
+++ b/tests/unit/main_html5/wrapper-event-tests.js
@@ -529,7 +529,7 @@ describe('main_html5 wrapper tests', function () {
     }]);
   });
 
-  it('should NOT readd manually added tracks to available captions when in-manifest/in-stream tracks are checked', function() {
+  it('should NOT re-add manually added tracks to available captions when in-manifest/in-stream tracks are checked', function() {
     var isLive = true;
     OO.isSafari = true;
     element.textTracks = [

--- a/tests/unit/main_html5/wrapper-event-tests.js
+++ b/tests/unit/main_html5/wrapper-event-tests.js
@@ -529,6 +529,37 @@ describe('main_html5 wrapper tests', function () {
     }]);
   });
 
+  it('should NOT readd manually added tracks to available captions when in-manifest/in-stream tracks are checked', function() {
+    var isLive = true;
+    OO.isSafari = true;
+    element.textTracks = [
+      { language: "", label: "", kind: "subtitles" },
+      { language: "", label: "", kind: "subtitles" },
+      { language: "", label: "", kind: "subtitles" }
+    ];
+    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS, isLive);
+    wrapper.setClosedCaptions("en", closedCaptions, { mode: "hidden" });
+    // Simulate manually added track showing up on video element's textTracks property
+    var newTrackId = $(element).find('track').get(0).id;
+    element.textTracks.push({
+      id: newTrackId,
+      language: "en",
+      label: "English",
+      kind: "subtitles"
+    });
+    // Check for stream captions
+    $(element).triggerHandler("playing");
+    expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.CAPTIONS_FOUND_ON_PLAYING, {
+      languages: ['en', 'CC1', 'CC2', 'CC3'],
+      locale: {
+        en: 'English',
+        CC1: 'Captions (CC1)',
+        CC2: 'Captions (CC2)',
+        CC3: 'Captions (CC3)'
+      }
+    }]);
+  });
+
   it('should notify CLOSED_CAPTION_CUE_CHANGED from onClosedCaptionCueChange event on textTrack', function(){
     var event = {
       currentTarget: {

--- a/tests/unit/main_html5/wrapper-event-tests.js
+++ b/tests/unit/main_html5/wrapper-event-tests.js
@@ -421,24 +421,24 @@ describe('main_html5 wrapper tests', function () {
     element.textTracks = [{ kind: "captions" }];
     $(element).triggerHandler("playing"); // this adds in-stream captions
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.CAPTIONS_FOUND_ON_PLAYING, {
-      languages: ['CC'],
+      languages: ['CC1'],
       locale: {
-        CC: 'In-Stream'
+        CC1: 'CC1'
       }
     }]);
   });
 
   it('should notify CAPTIONS_FOUND_ON_PLAYING on first video \'playing\' event for both live and external CCs on Safari (or Edge)', function(){
     OO.isSafari = true;
-    element.textTracks = [{ language: "en", label: "English", kind: "subtitles" }]; // this is external CC
+    element.textTracks = [{ language: "en", label: "", kind: "subtitles" }]; // this is external CC
     wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS, true); // sets isLive flag to true
     wrapper.setClosedCaptions("en", closedCaptions, {mode: "hidden"}); // creates text tracks for external CCs
     $(element).triggerHandler("playing"); // adds in-stream captions
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.CAPTIONS_FOUND_ON_PLAYING, {
-      languages: ['en', 'CC'],
+      languages: ['en', 'CC1'],
       locale: {
         en: 'English',
-        CC: 'In-Stream'
+        CC1: 'CC1'
       }
     }]);
   });
@@ -450,7 +450,7 @@ describe('main_html5 wrapper tests', function () {
     $(element).triggerHandler("playing"); // this adds in-stream captions
 
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.CAPTIONS_FOUND_ON_PLAYING, {
-      languages: ['CC'], locale: { CC: 'In-Stream' }}]);
+      languages: ['CC1'], locale: { CC1: 'CC1' }}]);
   });
 
   it('should notify CLOSED_CAPTION_CUE_CHANGED from onClosedCaptionCueChange event on textTrack', function(){


### PR DESCRIPTION
MainHtml5 is currently only able to handle a single in-manifest/in-stream text track. This is a workaround that enables displaying and selecting multiple in-manifest/in-stream text tracks.