### PR TITLE
[PLAYER-4216] (PR 3 of 3) MainHtml5 closed captions refactor

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,12 @@
 {
-  "presets": [ "@babel/preset-env" ]
+  "presets": [
+    [
+      "@babel/preset-env", {
+        "targets": {
+          "ie": 11
+        },
+        "useBuiltIns": "usage"
+      }
+    ]
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -608,6 +608,16 @@
         "regexpu-core": "4.2.0"
       }
     },
+    "@babel/polyfill": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0.tgz",
+      "integrity": "sha512-dnrMRkyyr74CRelJwvgnnSUDh2ge2NCTyHVwpOdvRMHtJUyxLtMAfhBN3s64pY41zdw0kgiLPh6S20eb1NcX6Q==",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
+      }
+    },
     "@babel/preset-env": {
       "version": "7.0.0-beta.56",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.56.tgz",

--- a/package.json
+++ b/package.json
@@ -13,11 +13,12 @@
     "test": "jest"
   },
   "devDependencies": {
-    "browserify": "16.2.2",
-    "babelify": "^9.0.0",
     "@babel/core": "^7.0.0-beta.51",
+    "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.0.0-beta.51",
     "babel-core": "^7.0.0-bridge.0",
+    "babelify": "^9.0.0",
+    "browserify": "16.2.2",
     "expect.js": "0.3.1",
     "file-lister": "^1.1.0",
     "gulp": "3.9.1",
@@ -30,11 +31,11 @@
     "jest-cli": "23.4.2",
     "jquery": "3.3.1",
     "jsdoc": "^3.3.3",
+    "sinon": "^6.0.0",
     "uglify": "^0.1.5",
     "underscore": "1.9.1",
     "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^2.0.0",
-    "sinon": "^6.0.0"
+    "vinyl-source-stream": "^2.0.0"
   },
   "repository": {
     "type": "git",

--- a/src/main/js/constants/constants.js
+++ b/src/main/js/constants/constants.js
@@ -1,0 +1,21 @@
+
+const CONSTANTS = {
+
+  ID_PREFIX: {
+    INTERNAL: 'CC',
+    EXTERNAL: 'VTT',
+  },
+
+  TEXT_TRACK: {
+    KIND: {
+      SUBTITLES: 'subtitles',
+      CAPTIONS: 'captions',
+      DESCRIPTIONS: 'descriptions',
+      CHAPTERS: 'chapters',
+      METADATA: 'metadata',
+    }
+  },
+
+};
+
+export default CONSTANTS;

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -209,6 +209,7 @@ import CONSTANTS from "./constants/constants";
     var originalPreloadValue = $(_video).attr("preload") || "none";
     var currentPlaybackSpeed = 1.0;
 
+    let currentCCKey = '';
     let setClosedCaptionsQueue = [];
     let externalCaptionsLanguages = {};
     const textTrackMap = new TextTrackMap();
@@ -364,6 +365,7 @@ import CONSTANTS from "./constants/constants";
       isPriming = false;
       stopUnderflowWatcher();
       lastCueText = null;
+      currentCCKey = '';
       setClosedCaptionsQueue = [];
       externalCaptionsLanguages = {};
       textTrackHelper.removeExternalTracks(textTrackMap);
@@ -798,6 +800,11 @@ import CONSTANTS from "./constants/constants";
       const vttClosedCaptions = closedCaptions.closed_captions_vtt || {};
       const targetMode = params.mode || OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING;
       const targetTrack = textTrackHelper.findTrackByKey(language, textTrackMap);
+      // Clear current CC cue if track is about to change
+      if (currentCCKey !== language) {
+        raiseClosedCaptionCueChanged('');
+      }
+      currentCCKey = language;
       // Start by disabling all tracks, except for the one whose mode we want to set
       disableTextTracksExcept(targetTrack);
       // Create tracks for all VTT captions from content tree that we haven't

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -1065,7 +1065,6 @@ import CONSTANTS from "./constants/constants";
         // enabled by the user via the native UI
         } else if (!textTrackMap.areAllDisabled() && changedTracks.length === 1) {
           OO.log('MainHtml5: Default browser CC language detected, ignoring in favor of plugin default');
-          changedTrack.mode = trackMetadata.mode;
         } else {
           const useLanguageAsKey = !!(
             trackMetadata.isExternal ||
@@ -1077,11 +1076,10 @@ import CONSTANTS from "./constants/constants";
           // whenever both internal and external tracks exist for the same language
           newLanguage = useLanguageAsKey ? trackMetadata.language : trackMetadata.id;
         }
-        // Make sure to remember the new mode that was set by the native UI
-        textTrackMap.tryUpdateEntry(
-          { id: trackMetadata.id },
-          { mode: changedTrack.mode }
-        );
+        // Whether we're ignoring or propagating the changes we revert the track to
+        // it's last known mode. If there's a need for a language change it will
+        // happen as a result of the notification below
+        changedTrack.mode = trackMetadata.mode;
       }
       // Native text track change detected, update our own UI
       if (newLanguage) {

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -967,7 +967,6 @@ import CONSTANTS from "./constants/constants";
     var onLoadedMetadata = _.bind(function() {
       if (_video.textTracks) {
         _video.textTracks.onaddtrack = onTextTracksAddTrack;
-        _video.textTracks.onremovetrack = onTextTracksRemoveTrack;
         _video.textTracks.onchange = onTextTracksChange;
       }
       // Execute any setClosedCaptions calls that occurred while
@@ -1020,18 +1019,6 @@ import CONSTANTS from "./constants/constants";
      * @private
      */
     const onTextTracksAddTrack = () => {
-      // Update our internal map of available text tracks
-      tryMapTextTracks();
-      // Notify core about closed captions available after the change
-      checkForAvailableClosedCaptions();
-    };
-
-    /**
-     * Fired by the browser when text tracks are removed.
-     * @method OoyalaVideoWrapper#onTextTracksRemoveTrack
-     * @private
-     */
-    const onTextTracksRemoveTrack = () => {
       // Update our internal map of available text tracks
       tryMapTextTracks();
       // Notify core about closed captions available after the change

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -753,8 +753,7 @@ import CONSTANTS from "./constants/constants";
      *  - mode: (String) The mode to set on the track that matches the language parameter
      */
     this.setClosedCaptions = _.bind(function(language, closedCaptions = {}, params = {}) {
-      console.log(">>>>setClosedCaptions", language);
-
+      OO.log("MainHtml5: setClosedCaptions called", language, closedCaptions, params);
       const vttClosedCaptions = closedCaptions.closed_captions_vtt || {};
       const externalCaptionsProvided = !!Object.keys(vttClosedCaptions).length;
       // Most browsers will require crossorigin=anonymous in order to be able to
@@ -770,7 +769,7 @@ import CONSTANTS from "./constants/constants";
         dequeueSetClosedCaptions();
         executeSetClosedCaptions.apply(this, arguments);
       } else {
-        OO.log('>>>>MainHtml5: setClosedCaptions called before metadata loaded, queing operation.');
+        OO.log('MainHtml5: setClosedCaptions called before metadata loaded, queing operation.');
         setClosedCaptionsQueue.push(arguments);
       }
     }, this);
@@ -1055,7 +1054,7 @@ import CONSTANTS from "./constants/constants";
           // A single enabled track (without a corresponding disabled track) indicates
           // that the browser is forcing its default language. We ignore it in favor
           // of our own default language
-          OO.log('>>>>MainHtml5: Default browser CC language detected, ignoring in favor of plugin default');
+          OO.log('MainHtml5: Default browser CC language detected, ignoring in favor of plugin default');
           changedTrack.mode = trackMetadata.mode;
         } else {
           newLanguage = trackMetadata.isExternal ? trackMetadata.language : trackMetadata.id;
@@ -1072,7 +1071,7 @@ import CONSTANTS from "./constants/constants";
           this.controller.EVENTS.CAPTIONS_LANGUAGE_CHANGE,
           { language: newLanguage }
         );
-        OO.log(`>>>>MainHtml5: CC track has been changed to "${newLanguage}" by the native UI`);
+        OO.log(`MainHtml5: CC track has been changed to "${newLanguage}" by the native UI`);
       }
     };
 
@@ -1571,7 +1570,7 @@ import CONSTANTS from "./constants/constants";
         });
 
         if (trackMetadata) {
-          OO.log(">>>>MainHtml5: Registering newly added text track:", trackMetadata.id);
+          OO.log("MainHtml5: Registering newly added text track:", trackMetadata.id);
           // Store a reference to the track on our track map in order to link
           // related metadata
           textTrackMap.tryUpdateEntry(
@@ -1585,7 +1584,7 @@ import CONSTANTS from "./constants/constants";
           // Tracks are added as 'disabled' by default so we make sure to set
           // the mode that we had previously stored for the newly added track.
           // Note that track mode can't be set during creation that's why we
-          // need to wait until the browser reports the track addtion.
+          // need to wait until the browser reports the track addition.
           setTextTrackMode(textTrack, trackMetadata.mode);
         }
         // Add in-manifest/in-stream tracks to our text track map. All external
@@ -1608,6 +1607,7 @@ import CONSTANTS from "./constants/constants";
       const isKnownTrack = textTrackMap.existsEntry({
         textTrack: textTrack
       });
+      // Avoid mapping metadata and other non-subtitle track kinds
       const isTextTrack = (
         textTrack.kind === CONSTANTS.TEXT_TRACK.KIND.CAPTIONS ||
         textTrack.kind === CONSTANTS.TEXT_TRACK.KIND.SUBTITLES
@@ -1615,7 +1615,7 @@ import CONSTANTS from "./constants/constants";
       // Add an entry to our text track map in order to be able to keep track of
       // the in-manifest/in-stream track's mode
       if (!isKnownTrack && isTextTrack) {
-        OO.log(">>>>MainHtml5: Registering internal text track:", textTrack);
+        OO.log("MainHtml5: Registering internal text track:", textTrack);
 
         textTrackMap.addEntry({
           label: textTrack.label,
@@ -1694,7 +1694,7 @@ import CONSTANTS from "./constants/constants";
         } else {
           textTrack.oncuechange = onClosedCaptionCueChange;
         }
-        OO.log('>>>>MainHtml5: Text track mode set:', textTrack.language, mode);
+        OO.log('MainHtml5: Text track mode set:', textTrack.language, mode);
       }
     };
 

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -1576,6 +1576,10 @@ import CONSTANTS from "./constants/constants";
         srclang: trackData.language,
         src: trackData.url
       });
+      // MS Edge doesn't fire the addtrack event for manually added tracks
+      if (OO.isEdge) {
+        onTextTracksAddTrack();
+      }
     };
 
     /**
@@ -1614,7 +1618,7 @@ import CONSTANTS from "./constants/constants";
           setTextTrackMode(textTrack, trackMetadata.mode);
         }
         // Add in-manifest/in-stream tracks to our text track map. All external
-        // tracks are already known to use, so any unrecognized tracks are assumed
+        // tracks are already known to us, so any unrecognized tracks are assumed
         // to be in-manifest/in-stream
         mapTextTrackIfUnknown(textTrack);
       });
@@ -1692,7 +1696,7 @@ import CONSTANTS from "./constants/constants";
             `Captions (${key})`
           );
           // For in-manifest/in-stream we use id instead of language in order to
-          // account for cases in which lanugage metadata is unavailable and also
+          // account for cases in which language metadata is unavailable and also
           // to avoid conflicts with external VTT captions
           closedCaptionInfo.languages.push(key);
           closedCaptionInfo.locale[key] = label;

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -754,12 +754,6 @@ import CONSTANTS from "./constants/constants";
      */
     this.setClosedCaptions = _.bind(function(language, closedCaptions = {}, params = {}) {
       console.log(">>>>setClosedCaptions", language);
-      // Most browsers will require crossorigin=anonymous in order to be able to
-      // load VTT files from a different domain. This needs to happen before any
-      // tracks are added
-      this.setCrossorigin('anonymous');
-      // Disable all tracks first
-      this.setClosedCaptionsMode(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
 
       if (metadataLoaded) {
         dequeueSetClosedCaptions();
@@ -786,7 +780,16 @@ import CONSTANTS from "./constants/constants";
      */
     const executeSetClosedCaptions = (language, closedCaptions = {}, params = {}) => {
       const vttClosedCaptions = closedCaptions.closed_captions_vtt || {};
+      const externalCaptionsProvided = !!Object.keys(vttClosedCaptions).length;
       const targetMode = params.mode || OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING;
+      // Most browsers will require crossorigin=anonymous in order to be able to
+      // load VTT files from a different domain. This needs to happen before any
+      // tracks are added. We only do this if we're actually adding external tracks
+      if (externalCaptionsProvided) {
+        this.setCrossorigin('anonymous');
+      }
+      // Start by disabling all tracks
+      this.setClosedCaptionsMode(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
       // Create tracks for all VTT captions from content tree that we haven't
       // added before. If the track with the specified language is added, it
       // will be created with the desired mode automatically

--- a/src/main/js/text_track/text_track_helper.js
+++ b/src/main/js/text_track/text_track_helper.js
@@ -22,6 +22,35 @@ export default class TextTrackHelper {
     Array.prototype.forEach.call(this.video.textTracks, callback);
   }
 
+  filter(callback) {
+    if (!this.video || !this.video.textTracks) {
+      return [];
+    }
+    return Array.prototype.filter.call(this.video.textTracks, callback);
+  }
+
+  filterExternal(externalTextTrackMap) {
+    const externalTracks = this.filter(currentTrack =>
+      externalTextTrackMap.existsEntry({
+        id: currentTrack.id
+      })
+    );
+    return externalTracks;
+  }
+
+  filterInternal(externalTextTrackMap) {
+    const internalTracks = this.filter(currentTrack => {
+      const isInternal = !externalTextTrackMap.existsEntry({
+        id: currentTrack.id
+      });
+      const isText = (
+        currentTrack.kind === 'captions' || currentTrack.kind === 'subtitles'
+      );
+      return isInternal && isText;
+    });
+    return internalTracks;
+  }
+
   findTrack(callback) {
     if (!this.video || !this.video.textTracks) {
       return;
@@ -45,5 +74,16 @@ export default class TextTrackHelper {
       return matchesLanguage || matchesTrackIdLanguage;
     });
     return track;
+  }
+
+  removeExternalTracks(externalTextTrackMap) {
+    for (let trackMetadata of externalTextTrackMap.textTracks) {
+      const trackElement = document.getElementById(trackMetadata.id);
+
+      if (trackElement) {
+        trackElement.remove();
+      }
+    }
+    externalTextTrackMap.clear();
   }
 }

--- a/src/main/js/text_track/text_track_helper.js
+++ b/src/main/js/text_track/text_track_helper.js
@@ -1,7 +1,8 @@
 import TextTrackMap from "./text_track_map";
 
 /**
- *
+ * Extends the functionality of the TextTrackList object in order to simplify
+ * adding, searching, updating and removing text tracks.
  */
 export default class TextTrackHelper {
 
@@ -10,14 +11,14 @@ export default class TextTrackHelper {
   }
 
   /**
-   *
+   * Creates a new TextTrack object by appending Track element to the video element.
    * @public
-   * @param {Object} trackData
+   * @param {Object} trackData An object with the relevant properties to set on the text track object.
    */
-  addTrack(trackData) {
+  addTrack(trackData = {}) {
     const track = document.createElement('track');
     track.id = trackData.id;
-    track.kind = 'subtitles';
+    track.kind = trackData.kind;
     track.label = trackData.label;
     track.srclang = trackData.srclang;
     track.src = trackData.src;
@@ -25,12 +26,13 @@ export default class TextTrackHelper {
   }
 
   /**
-   *
-   * @private
-   * @param {String} trackId
-   * @param {String} label
+   * Finds a text track by id and sets its label to the given value. This operation
+   * is only possible for tracks that were manually added by the plugin.
+   * @public
+   * @param {String} trackId The dom id of the text track to update
+   * @param {String} label The new label to be set on the text track
    */
-  updateLabel(trackId, label = '') {
+  updateTrackLabel(trackId, label = '') {
     if (this.video && trackId) {
       const trackElement = this.video.querySelector(`#${trackId}`);
 
@@ -41,9 +43,9 @@ export default class TextTrackHelper {
   }
 
   /**
-   *
+   * Allows executing Array.prototype.forEach on the video's TextTrackList.
    * @public
-   * @param  {type} callback
+   * @param {Function} callback A function to execute for existing text track.
    */
   forEach(callback) {
     if (!this.video || !this.video.textTracks) {
@@ -53,10 +55,10 @@ export default class TextTrackHelper {
   }
 
   /**
-   *
+   * Allows executing Array.prototype.filter on the video's TextTrackList.
    * @public
-   * @param {Function} callback
-   * @return {Array}
+   * @param {Function} callback A predicate function to test each element of the array.
+   * @return {Array} An array with all the TextTrack objects that match the filter criteria.
    */
   filter(callback) {
     if (!this.video || !this.video.textTracks) {
@@ -66,10 +68,10 @@ export default class TextTrackHelper {
   }
 
   /**
-   *
+   * Allows executing Array.prototype.find on the video's TextTrackList.
    * @public
-   * @param {Function} callback
-   * @return {TextTrack}
+   * @param {Function} callback A function to execute on each value in the array.
+   * @return {TextTrack} The first TextTrack object that matches the search criteria or undefined if there are no matches.
    */
   find(callback) {
     if (!this.video || !this.video.textTracks) {
@@ -80,11 +82,12 @@ export default class TextTrackHelper {
   }
 
   /**
-   *
+   * Finds the TextTrack object that matches a key, which can be either the language
+   * code of the track or a track id associated with the track on a TextTrackMap.
    * @public
-   * @param {String} languageOrId
-   * @param {TextTrackMap} textTrackMap
-   * @return {TextTrack}
+   * @param {String} languageOrId The language or track id of the track we want to find.
+   * @param {TextTrackMap} textTrackMap A TextTrackMap that contains metadata for all of the video's TextTrack objects.
+   * @return {TextTrack} The first TextTrack object that matches the given key or undefined if there are no matches.
    */
   findTrackByKey(languageOrId, textTrackMap = new TextTrackMap()) {
     let track = this.find(currentTrack => {
@@ -101,10 +104,12 @@ export default class TextTrackHelper {
   }
 
   /**
-   *
+   * Returns a list with all of the TextTrack objects whose track mode is different
+   * from the value stored in the given TextTrackMap.
    * @public
-   * @param {TextTrackMap} textTrackMap
-   * @return {Array}
+   * @param {TextTrackMap} textTrackMap A TextTrackMap that contains metadata for all of the video's TextTrack objects.
+   * @return {Array} An array with all of the TextTrack objects that match the search
+   * criteria or an empty array if there are no matches.
    */
   filterChangedTracks(textTrackMap = new TextTrackMap()) {
     const changedTracks = this.filter(currentTrack => {
@@ -122,9 +127,10 @@ export default class TextTrackHelper {
   }
 
   /**
-   *
+   * Finds and removes any TextTracks that marked as external on the given
+   * TextTrackMap.
    * @public
-   * @param {TextTrackMap} textTrackMap
+   * @param {TextTrackMap} textTrackMap A TextTrackMap that contains metadata for all of the video's TextTrack objects.
    */
   removeExternalTracks(textTrackMap = TextTrackMap()) {
     for (let trackMetadata of textTrackMap.getExternalEntries()) {

--- a/src/main/js/text_track/text_track_helper.js
+++ b/src/main/js/text_track/text_track_helper.js
@@ -6,21 +6,13 @@ export default class TextTrackHelper {
   }
 
   addTrack(trackData) {
-    return new Promise(resolve => {
-      const track = document.createElement('track');
-      track.id = trackData.id;
-      track.kind = 'subtitles';
-      track.label = trackData.label;
-      track.srclang = trackData.language;
-      track.src = trackData.sourceUrl;
-
-      track.addEventListener('load', () => {
-        const newlyAddedTextTrack = this.findTrackById(track.id);
-        resolve(newlyAddedTextTrack);
-      });
-
-      this.video.appendChild(track);
-    });
+    const track = document.createElement('track');
+    track.id = trackData.id;
+    track.kind = 'subtitles';
+    track.label = trackData.label;
+    track.srclang = trackData.srclang;
+    track.src = trackData.src;
+    this.video.appendChild(track);
   }
 
   findTrack(callback) {

--- a/src/main/js/text_track/text_track_helper.js
+++ b/src/main/js/text_track/text_track_helper.js
@@ -1,3 +1,4 @@
+import TextTrackMap from "./text_track_map";
 
 export default class TextTrackHelper {
 
@@ -29,28 +30,6 @@ export default class TextTrackHelper {
     return Array.prototype.filter.call(this.video.textTracks, callback);
   }
 
-  filterExternal(externalTextTrackMap) {
-    const externalTracks = this.filter(currentTrack =>
-      externalTextTrackMap.existsEntry({
-        id: currentTrack.id
-      })
-    );
-    return externalTracks;
-  }
-
-  filterInternal(externalTextTrackMap) {
-    const internalTracks = this.filter(currentTrack => {
-      const isInternal = !externalTextTrackMap.existsEntry({
-        id: currentTrack.id
-      });
-      const isText = (
-        currentTrack.kind === 'captions' || currentTrack.kind === 'subtitles'
-      );
-      return isInternal && isText;
-    });
-    return internalTracks;
-  }
-
   findTrack(callback) {
     if (!this.video || !this.video.textTracks) {
       return;
@@ -76,14 +55,37 @@ export default class TextTrackHelper {
     return track;
   }
 
-  removeExternalTracks(externalTextTrackMap) {
-    for (let trackMetadata of externalTextTrackMap.textTracks) {
+  getInternalTracks(textTrackMap = new TextTrackMap()) {
+    const internalTracks = this.filter(currentTrack => {
+      const isInternal = !textTrackMap.existsEntry({
+        id: currentTrack.id,
+        isExternal: true
+      });
+      const isText = (
+        currentTrack.kind === 'captions' || currentTrack.kind === 'subtitles'
+      );
+      return isInternal && isText;
+    });
+    return internalTracks;
+  }
+
+  getExternalTracks(textTrackMap = new TextTrackMap()) {
+    const externalTracks = this.filter(currentTrack =>
+      textTrackMap.existsEntry({
+        id: currentTrack.id,
+        isExternal: true
+      })
+    );
+    return externalTracks;
+  }
+
+  removeExternalTracks(textTrackMap = TextTrackMap()) {
+    for (let trackMetadata of textTrackMap.getExternalEntries()) {
       const trackElement = document.getElementById(trackMetadata.id);
 
       if (trackElement) {
         trackElement.remove();
       }
     }
-    externalTextTrackMap.clear();
   }
 }

--- a/src/main/js/text_track/text_track_helper.js
+++ b/src/main/js/text_track/text_track_helper.js
@@ -16,6 +16,9 @@ export default class TextTrackHelper {
    * @param {Object} trackData An object with the relevant properties to set on the text track object.
    */
   addTrack(trackData = {}) {
+    if (!this.video) {
+      return;
+    }
     const track = document.createElement('track');
     track.id = trackData.id;
     track.kind = trackData.kind;
@@ -133,8 +136,12 @@ export default class TextTrackHelper {
    * @param {TextTrackMap} textTrackMap A TextTrackMap that contains metadata for all of the video's TextTrack objects.
    */
   removeExternalTracks(textTrackMap = TextTrackMap()) {
+    if (!this.video) {
+      return;
+    }
+
     for (let trackMetadata of textTrackMap.getExternalEntries()) {
-      const trackElement = document.getElementById(trackMetadata.id);
+      const trackElement = this.video.querySelector(`#${trackMetadata.id}`);
 
       if (trackElement) {
         trackElement.remove();

--- a/src/main/js/text_track/text_track_helper.js
+++ b/src/main/js/text_track/text_track_helper.js
@@ -1,0 +1,50 @@
+
+export default class TextTrackHelper {
+
+  constructor(video) {
+    this.video = video;
+  }
+
+  addTrack(trackData) {
+    return new Promise(resolve => {
+      const track = document.createElement('track');
+      track.id = trackData.id;
+      track.kind = 'subtitles';
+      track.label = trackData.label;
+      track.srclang = trackData.language;
+      track.src = trackData.sourceUrl;
+
+      track.addEventListener('load', () => {
+        const newlyAddedTextTrack = this.findTrackById(track.id);
+        resolve(newlyAddedTextTrack);
+      });
+
+      this.video.appendChild(track);
+    });
+  }
+
+  findTrack(callback) {
+    if (!this.video || !this.video.textTracks) {
+      return;
+    }
+    let track = Array.prototype.find.call(this.video.textTracks, callback);
+    return track;
+  }
+
+  findTrackById(id) {
+    let track = this.findTrack(currentTrack =>
+      currentTrack.id === id || currentTrack.trackId === id
+    );
+    return track;
+  }
+
+  findTrackByLanguage(language) {
+    let track = this.findTrack(currentTrack => {
+      const matchesLanguage = currentTrack.language === language && !currentTrack.trackId;
+      const matchesTrackIdLanguage = currentTrack.trackId === language;
+
+      return matchesLanguage || matchesTrackIdLanguage;
+    });
+    return track;
+  }
+}

--- a/src/main/js/text_track/text_track_helper.js
+++ b/src/main/js/text_track/text_track_helper.js
@@ -16,6 +16,16 @@ export default class TextTrackHelper {
     this.video.appendChild(track);
   }
 
+  updateLabel(trackId, label = '') {
+    if (this.video && trackId) {
+      const trackElement = this.video.querySelector(`#${trackId}`);
+
+      if (trackElement) {
+        trackElement.setAttribute('label', label);
+      }
+    }
+  }
+
   forEach(callback) {
     if (!this.video || !this.video.textTracks) {
       return;
@@ -38,19 +48,16 @@ export default class TextTrackHelper {
     return track;
   }
 
-  findTrackById(id) {
-    let track = this.findTrack(currentTrack =>
-      currentTrack.id === id || currentTrack.trackId === id
-    );
-    return track;
-  }
-
-  findTrackByLanguage(language) {
+  findTrackByKey(languageOrId, textTrackMap = new TextTrackMap()) {
     let track = this.findTrack(currentTrack => {
-      const matchesLanguage = currentTrack.language === language && !currentTrack.trackId;
-      const matchesTrackIdLanguage = currentTrack.trackId === language;
+      const trackMetadata = textTrackMap.findEntry({
+        textTrack: currentTrack
+      });
+      const matchesTrackId = !!trackMetadata && trackMetadata.id === languageOrId;
+      const matchesLanguage = currentTrack.language === languageOrId;
+      const keyMatchesTrack = matchesTrackId || matchesLanguage;
 
-      return matchesLanguage || matchesTrackIdLanguage;
+      return keyMatchesTrack;
     });
     return track;
   }
@@ -58,7 +65,7 @@ export default class TextTrackHelper {
   getInternalTracks(textTrackMap = new TextTrackMap()) {
     const internalTracks = this.filter(currentTrack => {
       const isInternal = !textTrackMap.existsEntry({
-        id: currentTrack.id,
+        textTrack: currentTrack,
         isExternal: true
       });
       const isText = (
@@ -72,7 +79,7 @@ export default class TextTrackHelper {
   getExternalTracks(textTrackMap = new TextTrackMap()) {
     const externalTracks = this.filter(currentTrack =>
       textTrackMap.existsEntry({
-        id: currentTrack.id,
+        textTrack: currentTrack,
         isExternal: true
       })
     );

--- a/src/main/js/text_track/text_track_helper.js
+++ b/src/main/js/text_track/text_track_helper.js
@@ -15,6 +15,13 @@ export default class TextTrackHelper {
     this.video.appendChild(track);
   }
 
+  forEach(callback) {
+    if (!this.video || !this.video.textTracks) {
+      return;
+    }
+    Array.prototype.forEach.call(this.video.textTracks, callback);
+  }
+
   findTrack(callback) {
     if (!this.video || !this.video.textTracks) {
       return;

--- a/src/main/js/text_track/text_track_helper.js
+++ b/src/main/js/text_track/text_track_helper.js
@@ -1,11 +1,19 @@
 import TextTrackMap from "./text_track_map";
 
+/**
+ *
+ */
 export default class TextTrackHelper {
 
   constructor(video) {
     this.video = video;
   }
 
+  /**
+   *
+   * @public
+   * @param {Object} trackData
+   */
   addTrack(trackData) {
     const track = document.createElement('track');
     track.id = trackData.id;
@@ -16,6 +24,12 @@ export default class TextTrackHelper {
     this.video.appendChild(track);
   }
 
+  /**
+   *
+   * @private
+   * @param {String} trackId
+   * @param {String} label
+   */
   updateLabel(trackId, label = '') {
     if (this.video && trackId) {
       const trackElement = this.video.querySelector(`#${trackId}`);
@@ -26,6 +40,11 @@ export default class TextTrackHelper {
     }
   }
 
+  /**
+   *
+   * @public
+   * @param  {type} callback
+   */
   forEach(callback) {
     if (!this.video || !this.video.textTracks) {
       return;
@@ -33,6 +52,12 @@ export default class TextTrackHelper {
     Array.prototype.forEach.call(this.video.textTracks, callback);
   }
 
+  /**
+   *
+   * @public
+   * @param {Function} callback
+   * @return {Array}
+   */
   filter(callback) {
     if (!this.video || !this.video.textTracks) {
       return [];
@@ -40,6 +65,12 @@ export default class TextTrackHelper {
     return Array.prototype.filter.call(this.video.textTracks, callback);
   }
 
+  /**
+   *
+   * @public
+   * @param {Function} callback
+   * @return {TextTrack}
+   */
   findTrack(callback) {
     if (!this.video || !this.video.textTracks) {
       return;
@@ -48,6 +79,13 @@ export default class TextTrackHelper {
     return track;
   }
 
+  /**
+   *
+   * @public
+   * @param {String} languageOrId
+   * @param {TextTrackMap} textTrackMap
+   * @return {TextTrack}
+   */
   findTrackByKey(languageOrId, textTrackMap = new TextTrackMap()) {
     let track = this.findTrack(currentTrack => {
       const trackMetadata = textTrackMap.findEntry({
@@ -62,30 +100,11 @@ export default class TextTrackHelper {
     return track;
   }
 
-  getInternalTracks(textTrackMap = new TextTrackMap()) {
-    const internalTracks = this.filter(currentTrack => {
-      const isInternal = !textTrackMap.existsEntry({
-        textTrack: currentTrack,
-        isExternal: true
-      });
-      const isText = (
-        currentTrack.kind === 'captions' || currentTrack.kind === 'subtitles'
-      );
-      return isInternal && isText;
-    });
-    return internalTracks;
-  }
-
-  getExternalTracks(textTrackMap = new TextTrackMap()) {
-    const externalTracks = this.filter(currentTrack =>
-      textTrackMap.existsEntry({
-        textTrack: currentTrack,
-        isExternal: true
-      })
-    );
-    return externalTracks;
-  }
-
+  /**
+   *
+   * @public
+   * @param {TextTrackMap} textTrackMap
+   */
   removeExternalTracks(textTrackMap = TextTrackMap()) {
     for (let trackMetadata of textTrackMap.getExternalEntries()) {
       const trackElement = document.getElementById(trackMetadata.id);

--- a/src/main/js/text_track/text_track_helper.js
+++ b/src/main/js/text_track/text_track_helper.js
@@ -71,7 +71,7 @@ export default class TextTrackHelper {
    * @param {Function} callback
    * @return {TextTrack}
    */
-  findTrack(callback) {
+  find(callback) {
     if (!this.video || !this.video.textTracks) {
       return;
     }
@@ -87,7 +87,7 @@ export default class TextTrackHelper {
    * @return {TextTrack}
    */
   findTrackByKey(languageOrId, textTrackMap = new TextTrackMap()) {
-    let track = this.findTrack(currentTrack => {
+    let track = this.find(currentTrack => {
       const trackMetadata = textTrackMap.findEntry({
         textTrack: currentTrack
       });
@@ -98,6 +98,27 @@ export default class TextTrackHelper {
       return keyMatchesTrack;
     });
     return track;
+  }
+
+  /**
+   *
+   * @public
+   * @param {TextTrackMap} textTrackMap
+   * @return {Array}
+   */
+  filterChangedTracks(textTrackMap = new TextTrackMap()) {
+    const changedTracks = this.filter(currentTrack => {
+      const trackMetadata = textTrackMap.findEntry({
+        textTrack: currentTrack
+      });
+      const hasTrackChanged = (
+        trackMetadata &&
+        currentTrack.mode !== trackMetadata.mode
+      );
+
+      return hasTrackChanged;
+    });
+    return changedTracks;
   }
 
   /**

--- a/src/main/js/text_track/text_track_map.js
+++ b/src/main/js/text_track/text_track_map.js
@@ -30,6 +30,11 @@ export default class TextTrackMap {
     return textTrack;
   };
 
+  existsEntry(searchOptions) {
+    const exists = !!this.findEntry(searchOptions);
+    return exists;
+  }
+
   tryUpdateEntry(searchOptions, metadata = {}) {
     const entry = this.findEntry(searchOptions);
 

--- a/src/main/js/text_track/text_track_map.js
+++ b/src/main/js/text_track/text_track_map.js
@@ -15,7 +15,7 @@ export default class TextTrackMap {
     return newTextTrack.id;
   }
 
-  findEntry(searchOptions) {
+  findEntry(searchOptions = {}) {
     const textTrack = this.textTracks.find(currentTrack => {
       let isFound = true;
 
@@ -29,6 +29,14 @@ export default class TextTrackMap {
     });
     return textTrack;
   };
+
+  tryUpdateEntry(searchOptions, metadata = {}) {
+    const entry = this.findEntry(searchOptions);
+
+    if (entry) {
+      Object.assign(entry, metadata);
+    }
+  }
 
   clear() {
     this.textTracks = [];

--- a/src/main/js/text_track/text_track_map.js
+++ b/src/main/js/text_track/text_track_map.js
@@ -4,12 +4,22 @@ const ID_PREFIX = {
   EXTERNAL: 'VTT',
 };
 
+/**
+ *
+ */
 export default class TextTrackMap {
 
   constructor() {
     this.textTracks = [];
   }
 
+  /**
+   *
+   * @public
+   * @param {Object} metadata
+   * @param {Boolean} isExternal
+   * @return {String}
+   */
   addEntry(metadata = {}, isExternal = false) {
     let idPrefix, trackCount;
 
@@ -20,16 +30,23 @@ export default class TextTrackMap {
       idPrefix = ID_PREFIX.INTERNAL;
       trackCount = this.getInternalEntries().length;
     }
-
+    // Generate new id based on the track count for the given track type
+    // (i.e. internal vs external)
     const newTextTrack = Object.assign({}, metadata, {
+      id: `${idPrefix}${trackCount + 1}`,
       isExternal: !!isExternal
     });
 
-    newTextTrack.id = `${idPrefix}${trackCount + 1}`;
     this.textTracks.push(newTextTrack);
     return newTextTrack.id;
   }
 
+  /**
+   *
+   * @public
+   * @param {Object} searchOptions
+   * @return {Object}
+   */
   findEntry(searchOptions = {}) {
     const textTrack = this.textTracks.find(currentTrack => {
       let isFound = true;
@@ -45,19 +62,38 @@ export default class TextTrackMap {
     return textTrack;
   };
 
+  /**
+   *
+   * @public
+   * @param {Object} searchOptions
+   * @return {Boolean}
+   */
   existsEntry(searchOptions) {
     const exists = !!this.findEntry(searchOptions);
     return exists;
   }
 
+  /**
+   *
+   * @public
+   * @param {Object} searchOptions
+   * @param {Object} metadata
+   * @return {Object}
+   */
   tryUpdateEntry(searchOptions, metadata = {}) {
-    const entry = this.findEntry(searchOptions);
+    let entry = this.findEntry(searchOptions);
 
     if (entry) {
-      Object.assign(entry, metadata);
+      entry = Object.assign(entry, metadata);
     }
+    return entry;
   }
 
+  /**
+   *
+   * @public
+   * @return {Array}
+   */
   getInternalEntries() {
     const internalEntries = this.textTracks.filter(trackMetadata =>
       !trackMetadata.isExternal
@@ -65,6 +101,11 @@ export default class TextTrackMap {
     return internalEntries;
   }
 
+  /**
+   *
+   * @public
+   * @return {Array}
+   */
   getExternalEntries() {
     const externalEntries = this.textTracks.filter(trackMetadata =>
       trackMetadata.isExternal
@@ -72,6 +113,10 @@ export default class TextTrackMap {
     return externalEntries;
   }
 
+  /**
+   *
+   * @public
+   */
   clear() {
     this.textTracks = [];
   };

--- a/src/main/js/text_track/text_track_map.js
+++ b/src/main/js/text_track/text_track_map.js
@@ -54,7 +54,10 @@ export default class TextTrackMap {
       let isFound = true;
 
       for (let property in searchOptions) {
-        if (searchOptions[property] !== currentTrack[property]) {
+        if (
+          searchOptions.hasOwnProperty(property) &&
+          searchOptions[property] !== currentTrack[property]
+        ) {
           isFound = false;
           break;
         }

--- a/src/main/js/text_track/text_track_map.js
+++ b/src/main/js/text_track/text_track_map.js
@@ -121,6 +121,18 @@ export default class TextTrackMap {
   }
 
   /**
+   * Determines whether or not all of the track entries are currently in 'disabled' mode.
+   * @public
+   * @return {Boolean} True if all tracks have 'disabled' mode, false otherwise
+   */
+  areAllDisabled() {
+    const allDisabled = this.textTracks.reduce((result, trackMetadata) =>
+      result && trackMetadata.mode === OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED
+    , true);
+    return allDisabled;
+  }
+
+  /**
    * Clears all the text track metadata and resets id generation.
    * @public
    */

--- a/src/main/js/text_track/text_track_map.js
+++ b/src/main/js/text_track/text_track_map.js
@@ -1,17 +1,32 @@
 
+const ID_PREFIX = {
+  INTERNAL: 'CC',
+  EXTERNAL: 'VTT',
+};
+
 export default class TextTrackMap {
 
-  constructor(idPrefix = 'textTrack') {
-    this.idPrefix = idPrefix;
+  constructor() {
     this.textTracks = [];
   }
 
-  addEntry(metadata = {}) {
-    const newTextTrack = Object.assign({}, metadata);
+  addEntry(metadata = {}, isExternal = false) {
+    let idPrefix, trackCount;
 
-    newTextTrack.id = `${this.idPrefix}${this.textTracks.length + 1}`;
+    if (isExternal) {
+      idPrefix = ID_PREFIX.EXTERNAL;
+      trackCount = this.getExternalEntries().length;
+    } else {
+      idPrefix = ID_PREFIX.INTERNAL;
+      trackCount = this.getInternalEntries().length;
+    }
+
+    const newTextTrack = Object.assign({}, metadata, {
+      isExternal: !!isExternal
+    });
+
+    newTextTrack.id = `${idPrefix}${trackCount + 1}`;
     this.textTracks.push(newTextTrack);
-
     return newTextTrack.id;
   }
 
@@ -41,6 +56,20 @@ export default class TextTrackMap {
     if (entry) {
       Object.assign(entry, metadata);
     }
+  }
+
+  getInternalEntries() {
+    const internalEntries = this.textTracks.filter(trackMetadata =>
+      !trackMetadata.isExternal
+    );
+    return internalEntries;
+  }
+
+  getExternalEntries() {
+    const externalEntries = this.textTracks.filter(trackMetadata =>
+      trackMetadata.isExternal
+    );
+    return externalEntries;
   }
 
   clear() {

--- a/src/main/js/text_track/text_track_map.js
+++ b/src/main/js/text_track/text_track_map.js
@@ -1,11 +1,9 @@
-
-const ID_PREFIX = {
-  INTERNAL: 'CC',
-  EXTERNAL: 'VTT',
-};
+import CONSTANTS from "../constants/constants";
 
 /**
- *
+ * Allows us to store and associate metadata with a TextTrack object since we
+ * can't store any data on the object itself. Automatically generates an id for
+ * registered tracks which can be used identify the object later.
  */
 export default class TextTrackMap {
 
@@ -14,20 +12,22 @@ export default class TextTrackMap {
   }
 
   /**
-   *
+   * Creates an entry in the TextTrackMap which represents a TextTrack object that
+   * has been added to or found in the video element. Automatically generates an id
+   * that can be used to identify the TextTrack later on.
    * @public
-   * @param {Object} metadata
-   * @param {Boolean} isExternal
-   * @return {String}
+   * @param {Object} metadata An object with metadata related to a TextTrack
+   * @param {Boolean} isExternal Determines whether or not the TextTrack was added by the plugin (i.e. is external)
+   * @return {String} The auto-generated id assigned to the newly registered track
    */
   addEntry(metadata = {}, isExternal = false) {
     let idPrefix, trackCount;
 
     if (isExternal) {
-      idPrefix = ID_PREFIX.EXTERNAL;
+      idPrefix = CONSTANTS.ID_PREFIX.EXTERNAL;
       trackCount = this.getExternalEntries().length;
     } else {
-      idPrefix = ID_PREFIX.INTERNAL;
+      idPrefix = CONSTANTS.ID_PREFIX.INTERNAL;
       trackCount = this.getInternalEntries().length;
     }
     // Generate new id based on the track count for the given track type
@@ -42,10 +42,12 @@ export default class TextTrackMap {
   }
 
   /**
-   *
+   * Finds the metadata that matches the given search options.
    * @public
-   * @param {Object} searchOptions
-   * @return {Object}
+   * @param {Object} searchOptions An object whose key value pairs will be matched against
+   * the existing entries. All existing properties in searchOptions need to match in order
+   * for a given entry to be matched.
+   * @return {Object} The metadata object that matches the given search options or undefined if there are no matches.
    */
   findEntry(searchOptions = {}) {
     const textTrack = this.textTracks.find(currentTrack => {
@@ -63,10 +65,12 @@ export default class TextTrackMap {
   };
 
   /**
-   *
+   * Determines whether or not there exists an entry that matches the given search options.
    * @public
-   * @param {Object} searchOptions
-   * @return {Boolean}
+   * @param {Object} searchOptions An object whose key value pairs will be matched against
+   * the existing entries. All existing properties in searchOptions need to match in order
+   * for a given entry to be matched.
+   * @return {Boolean} True if the entry exists, false otherwise
    */
   existsEntry(searchOptions) {
     const exists = !!this.findEntry(searchOptions);
@@ -74,11 +78,14 @@ export default class TextTrackMap {
   }
 
   /**
-   *
+   * Finds an entry with the given search options and merges the provided metadata
+   * with the existing object/
    * @public
-   * @param {Object} searchOptions
-   * @param {Object} metadata
-   * @return {Object}
+   * @param {Object} searchOptions An object whose key value pairs will be matched against
+   * the existing entries. All existing properties in searchOptions need to match in order
+   * for a given entry to be matched.
+   * @param {Object} metadata An object containing the properties to be merged with the existing object
+   * @return {Object} The updated metadata entry or undefined if there were no matches
    */
   tryUpdateEntry(searchOptions, metadata = {}) {
     let entry = this.findEntry(searchOptions);
@@ -90,9 +97,9 @@ export default class TextTrackMap {
   }
 
   /**
-   *
+   * Gets all of the entries associated with internal in-manifest/in-stream text tracks.
    * @public
-   * @return {Array}
+   * @return {Array} An array with all the internal TextTrack objects.
    */
   getInternalEntries() {
     const internalEntries = this.textTracks.filter(trackMetadata =>
@@ -102,9 +109,9 @@ export default class TextTrackMap {
   }
 
   /**
-   *
+   * Gets all of the entries associated with external, manually added text tracks.
    * @public
-   * @return {Array}
+   * @return {Array} An array with all the external TextTrack objects.
    */
   getExternalEntries() {
     const externalEntries = this.textTracks.filter(trackMetadata =>
@@ -114,7 +121,7 @@ export default class TextTrackMap {
   }
 
   /**
-   *
+   * Clears all the text track metadata and resets id generation.
    * @public
    */
   clear() {

--- a/src/main/js/text_track/text_track_map.js
+++ b/src/main/js/text_track/text_track_map.js
@@ -1,0 +1,36 @@
+
+export default class TextTrackMap {
+
+  constructor(idPrefix = 'textTrack') {
+    this.idPrefix = idPrefix;
+    this.textTracks = [];
+  }
+
+  addEntry(metadata = {}) {
+    const newTextTrack = Object.assign({}, metadata);
+
+    newTextTrack.id = `${this.idPrefix}${this.textTracks.length + 1}`;
+    this.textTracks.push(newTextTrack);
+
+    return newTextTrack.id;
+  }
+
+  findEntry(searchOptions) {
+    const textTrack = this.textTracks.find(currentTrack => {
+      let isFound = true;
+
+      for (let property in searchOptions) {
+        if (searchOptions[property] !== currentTrack[property]) {
+          isFound = false;
+          break;
+        }
+      }
+      return isFound;
+    });
+    return textTrack;
+  };
+
+  clear() {
+    this.textTracks = [];
+  };
+}

--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -120,6 +120,7 @@ describe('main_html5 wrapper tests', function () {
   it('should clear closed captions when setting a new url', function(){
     wrapper.setVideoUrl("url");
     $(element).triggerHandler("loadedmetadata");
+    $(element).triggerHandler("canplay");
     wrapper.setClosedCaptions(language, closedCaptions, params);
     element.textTracks.onaddtrack();
     // Make sure tracks are actually there before we remove them
@@ -132,6 +133,7 @@ describe('main_html5 wrapper tests', function () {
   it('should not clear closed captions when setting the same url', function(){
     wrapper.setVideoUrl("url");
     $(element).triggerHandler("loadedmetadata");
+    $(element).triggerHandler("canplay");
     element.textTracks.onaddtrack();
     wrapper.setClosedCaptions(language, closedCaptions, params);
     wrapper.setVideoUrl("url");
@@ -1151,6 +1153,7 @@ describe('main_html5 wrapper tests', function () {
   it('should set external closed captions', function(){
     wrapper.setVideoUrl("url");
     $(element).triggerHandler("loadedmetadata");
+    $(element).triggerHandler("canplay");
     wrapper.setClosedCaptions(language, closedCaptions, params);
     element.textTracks.onaddtrack();
     expect(element.children.length > 0).to.be(true);
@@ -1165,6 +1168,7 @@ describe('main_html5 wrapper tests', function () {
     element.textTracks = [{ mode: OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED, kind: "captions" }];
     wrapper.setVideoUrl("url");
     $(element).triggerHandler("loadedmetadata");
+    $(element).triggerHandler("canplay");
     element.textTracks.onaddtrack();
     expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
     wrapper.setClosedCaptions("CC1", {}, { mode: "showing" });
@@ -1175,6 +1179,7 @@ describe('main_html5 wrapper tests', function () {
     element.textTracks = [{ kind: "captions" }, { kind: "captions" }];
     wrapper.setVideoUrl("url");
     $(element).triggerHandler("loadedmetadata");
+    $(element).triggerHandler("canplay");
     element.textTracks.onaddtrack();
 
     wrapper.setClosedCaptionsMode(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
@@ -1204,6 +1209,7 @@ describe('main_html5 wrapper tests', function () {
     ];
     wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS);
     $(element).triggerHandler("loadedmetadata");
+    $(element).triggerHandler("canplay");
     element.textTracks.onaddtrack();
     wrapper.setClosedCaptions("CC3", {}, { mode: OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING });
     expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
@@ -1214,6 +1220,7 @@ describe('main_html5 wrapper tests', function () {
   it('should disable closed captions if language is null', function() {
     wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS);
     $(element).triggerHandler("loadedmetadata");
+    $(element).triggerHandler("canplay");
     wrapper.setClosedCaptions(language, closedCaptions, params);
     element.textTracks.onaddtrack();
     expect(element.children.length > 0).to.be(true);

--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -51,6 +51,7 @@ describe('main_html5 wrapper tests', function () {
     parentElement = $("<div>");
     wrapper = pluginFactory.create(parentElement, "test", vtc.interface, {});
     element = parentElement.children()[0];
+    element.textTracks = [];
     originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 3000;
   });
@@ -118,7 +119,9 @@ describe('main_html5 wrapper tests', function () {
 
   it('should clear closed captions when setting a new url', function(){
     wrapper.setVideoUrl("url");
+    $(element).triggerHandler("loadedmetadata");
     wrapper.setClosedCaptions(language, closedCaptions, params);
+    element.textTracks.onaddtrack();
     // Make sure tracks are actually there before we remove them
     expect(element.children.length > 0).to.be(true);
     expect(element.children[0].tagName).to.eql("TRACK");
@@ -128,8 +131,12 @@ describe('main_html5 wrapper tests', function () {
 
   it('should not clear closed captions when setting the same url', function(){
     wrapper.setVideoUrl("url");
+    $(element).triggerHandler("loadedmetadata");
+    element.textTracks.onaddtrack();
     wrapper.setClosedCaptions(language, closedCaptions, params);
     wrapper.setVideoUrl("url");
+    $(element).triggerHandler("loadedmetadata");
+    element.textTracks.onaddtrack();
     expect(element.children.length > 0).to.be(true);
     expect(element.children[0].tagName).to.eql("TRACK");
   });
@@ -1142,10 +1149,12 @@ describe('main_html5 wrapper tests', function () {
   });
 
   it('should set external closed captions', function(){
+    wrapper.setVideoUrl("url");
+    $(element).triggerHandler("loadedmetadata");
     wrapper.setClosedCaptions(language, closedCaptions, params);
+    element.textTracks.onaddtrack();
     expect(element.children.length > 0).to.be(true);
     expect(element.children[0].tagName).to.eql("TRACK");
-    expect(element.children[0].getAttribute("class")).to.eql(TRACK_CLASS);
     expect(element.children[0].getAttribute("kind")).to.eql("subtitles");
     expect(element.children[0].getAttribute("label")).to.eql("English");
     expect(element.children[0].getAttribute("src")).to.eql("http://ooyala.com");
@@ -1154,138 +1163,64 @@ describe('main_html5 wrapper tests', function () {
 
   it('should set closed captions mode for in-stream captions', function(){
     element.textTracks = [{ mode: OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED, kind: "captions" }];
-    $(element).triggerHandler("playing");
+    wrapper.setVideoUrl("url");
+    $(element).triggerHandler("loadedmetadata");
+    element.textTracks.onaddtrack();
     expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
-    wrapper.setClosedCaptions("CC1", null, { mode: "showing" });
+    wrapper.setClosedCaptions("CC1", {}, { mode: "showing" });
     expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING);
-  });
-
-  it('should replace French text tracks by English text tracks for iOS versions < 10 ', function(){
-    OO.iosMajorVersion = 9;
-    $(element).append("<track class='" + TRACK_CLASS + "' kind='subtitles' label='French' src='http://french.ooyala.com' srclang='fr'>");
-    wrapper.setClosedCaptions(language, closedCaptions, { mode: OO.CONSTANTS.CLOSED_CAPTIONS.HIDDEN });
-    expect(element.children.length).to.eql(1);
-    expect(element.children[0].tagName).to.eql("TRACK");
-    expect(element.children[0].getAttribute("label")).to.eql("English");
-    expect(element.children[0].getAttribute("kind")).to.eql("subtitles");
-    expect(element.children[0].getAttribute("src")).to.eql("http://ooyala.com");
-    expect(element.children[0].getAttribute("srclang")).to.eql("en");
-  });
-
-  it('should replace French text tracks by English text tracks for OSX/Safari versions < 10 ', function(){
-    OO.macOsSafariVersion = 9;
-    $(element).append("<track class='" + TRACK_CLASS + "' kind='subtitles' label='French' src='http://french.ooyala.com' srclang='fr'>");
-    wrapper.setClosedCaptions(language, closedCaptions, { mode: OO.CONSTANTS.CLOSED_CAPTIONS.HIDDEN });
-    expect(element.children.length).to.eql(1);
-    expect(element.children[0].tagName).to.eql("TRACK");
-    expect(element.children[0].getAttribute("label")).to.eql("English");
-    expect(element.children[0].getAttribute("kind")).to.eql("subtitles");
-    expect(element.children[0].getAttribute("src")).to.eql("http://ooyala.com");
-    expect(element.children[0].getAttribute("srclang")).to.eql("en");
-  });
-
-  it('should replace French subtitles by English ones on Safari version >= 10 and other platforms', function(){
-    OO.isChrome = true;
-    var closedCaptions2 = {
-      locale: { fr: "French" },
-      closed_captions_vtt: {
-        fr: {
-          name: "French",
-          url: "http://french.ooyala.com"
-        }
-      }
-    };
-
-    wrapper.setClosedCaptions('fr', closedCaptions2, { mode: OO.CONSTANTS.CLOSED_CAPTIONS.HIDDEN });
-    wrapper.setClosedCaptions(language, closedCaptions, { mode: OO.CONSTANTS.CLOSED_CAPTIONS.HIDDEN });
-    expect(element.children.length).to.eql(1);
-    expect(element.children[0].getAttribute("label")).to.eql("English");
-    expect(element.children[0].getAttribute("kind")).to.eql("subtitles");
-    expect(element.children[0].getAttribute("src")).to.eql("http://ooyala.com");
-    expect(element.children[0].getAttribute("srclang")).to.eql("en");
   });
 
   it('should set both in-stream and external closed captions and switches between them', function(){
     element.textTracks = [{ kind: "captions" }, { kind: "captions" }];
-    $(element).triggerHandler("playing"); // this adds in-stream captions
+    wrapper.setVideoUrl("url");
+    $(element).triggerHandler("loadedmetadata");
+    element.textTracks.onaddtrack();
 
     wrapper.setClosedCaptionsMode(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
     expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
     expect(element.textTracks[1].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
 
-    wrapper.setClosedCaptions("CC1", null, {mode: OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING});
+    wrapper.setClosedCaptions("CC1", {}, {mode: OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING});
     expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING);
     expect(element.textTracks[1].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
 
-    wrapper.setClosedCaptions("CC2", null, {mode: OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING});
+    wrapper.setClosedCaptions("CC2", {}, {mode: OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING});
     expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
     expect(element.textTracks[1].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING);
 
     wrapper.setClosedCaptions("en", closedCaptions, {mode: OO.CONSTANTS.CLOSED_CAPTIONS.HIDDEN}); // this adds external captions
-    expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.HIDDEN);
-    expect(element.textTracks[1].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.HIDDEN);
+    element.textTracks.onaddtrack();
+    expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
+    expect(element.textTracks[1].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
+    expect(element.textTracks[2].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.HIDDEN);
   });
 
   it('should only enable the in-manifest/in-stream track that matches language parameter', function() {
-    var isLive = true;
-    OO.isSafari = true;
     element.textTracks = [
       { language: "", label: "", kind: "subtitles" },
       { language: "", label: "", kind: "subtitles" },
       { language: "", label: "", kind: "subtitles" }
     ];
-    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS, isLive);
-    $(element).triggerHandler("playing");
-    wrapper.setClosedCaptions("CC3", null, { mode: OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING });
+    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS);
+    $(element).triggerHandler("loadedmetadata");
+    element.textTracks.onaddtrack();
+    wrapper.setClosedCaptions("CC3", {}, { mode: OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING });
     expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
     expect(element.textTracks[1].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
     expect(element.textTracks[2].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING);
   });
 
-  it('should set custom ids on in-manifest/in-stream tracks when stream tracks are checked', function() {
-    var isLive = true;
-    OO.isSafari = true;
-    element.textTracks = [
-      { language: "", label: "", kind: "subtitles" },
-      { language: "", label: "", kind: "subtitles" },
-      { language: "", label: "", kind: "subtitles" },
-      { language: "", label: "", kind: "subtitles" }
-    ];
-    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS, isLive);
-    $(element).triggerHandler("playing");
-    expect(element.textTracks[0].trackId).to.eql('CC1');
-    expect(element.textTracks[1].trackId).to.eql('CC2');
-    expect(element.textTracks[2].trackId).to.eql('CC3');
-    expect(element.textTracks[3].trackId).to.eql('CC4');
-  });
-
-  it('should set custom ids on in-manifest/in-stream tracks when closed captions are set if ids haven\'t been added yet', function() {
-    var isLive = true;
-    OO.isSafari = true;
-    element.textTracks = [
-      { language: "", label: "", kind: "subtitles" },
-      { language: "", label: "", kind: "subtitles" }
-    ];
-    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS, isLive);
-    $(element).triggerHandler("playing");
-    expect(element.textTracks[0].trackId).to.eql('CC1');
-    expect(element.textTracks[1].trackId).to.eql('CC2');
-    // Add some new tracks
-    element.textTracks.push({ language: "", label: "", kind: "subtitles" });
-    element.textTracks.push({ language: "", label: "", kind: "subtitles" });
-    wrapper.setClosedCaptions("CC2", null, { mode: OO.CONSTANTS.CLOSED_CAPTIONS.SHOWING });
-    expect(element.textTracks[0].trackId).to.eql('CC1');
-    expect(element.textTracks[1].trackId).to.eql('CC2');
-    expect(element.textTracks[2].trackId).to.eql('CC3');
-    expect(element.textTracks[3].trackId).to.eql('CC4');
-  });
-
-  it('should remove closed captions if language is null', function(){
+  it('should disable closed captions if language is null', function() {
+    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS);
+    $(element).triggerHandler("loadedmetadata");
     wrapper.setClosedCaptions(language, closedCaptions, params);
+    element.textTracks.onaddtrack();
     expect(element.children.length > 0).to.be(true);
     expect(element.children[0].tagName).to.eql("TRACK");
+    expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.HIDDEN);
     wrapper.setClosedCaptions(null, closedCaptions, params);
-    expect(element.children.length).to.eql(0);
+    expect(element.textTracks[0].mode).to.eql(OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED);
   });
 
   it('should set the closed captions mode', function(){

--- a/tests/unit/main_html5/wrapper-event-tests.js
+++ b/tests/unit/main_html5/wrapper-event-tests.js
@@ -444,6 +444,7 @@ describe('main_html5 wrapper tests', function () {
     element.textTracks = [{ language: "", label: "", kind: "subtitles" }]; // this is internal CC
     wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS);
     $(element).triggerHandler("loadedmetadata");
+    $(element).triggerHandler("canplay");
     wrapper.setClosedCaptions("en", closedCaptions, { mode: "hidden" }); // creates text tracks for external CCs
     element.textTracks.onaddtrack();
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.CAPTIONS_FOUND_ON_PLAYING, {
@@ -463,6 +464,7 @@ describe('main_html5 wrapper tests', function () {
     ];
     wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS);
     $(element).triggerHandler("loadedmetadata");
+    $(element).triggerHandler("canplay");
     wrapper.setClosedCaptions("en", closedCaptions, { mode: "hidden" });
     element.textTracks.onaddtrack();
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.CAPTIONS_FOUND_ON_PLAYING, {
@@ -484,6 +486,7 @@ describe('main_html5 wrapper tests', function () {
     ];
     wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS);
     $(element).triggerHandler("loadedmetadata");
+    $(element).triggerHandler("canplay");
     wrapper.setClosedCaptions("en", closedCaptions, { mode: "hidden" });
     element.textTracks.onaddtrack();
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.CAPTIONS_FOUND_ON_PLAYING, {
@@ -537,6 +540,7 @@ describe('main_html5 wrapper tests', function () {
     ];
     wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS);
     $(element).triggerHandler("loadedmetadata");
+    $(element).triggerHandler("canplay");
     wrapper.setClosedCaptions("en", closedCaptions, { mode: "hidden" });
     element.textTracks.onaddtrack();
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.CAPTIONS_FOUND_ON_PLAYING, {
@@ -560,6 +564,7 @@ describe('main_html5 wrapper tests', function () {
     };
     wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS);
     $(element).triggerHandler("loadedmetadata");
+    $(element).triggerHandler("canplay");
     wrapper.setClosedCaptions("en", closedCaptions, {mode: "hidden"});
     element.textTracks.onaddtrack();
     element.textTracks[0].oncuechange(event);
@@ -578,6 +583,7 @@ describe('main_html5 wrapper tests', function () {
     };
     wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS);
     $(element).triggerHandler("loadedmetadata");
+    $(element).triggerHandler("canplay");
     wrapper.setClosedCaptions("en", closedCaptions, {mode: "hidden"});
     element.textTracks.onaddtrack();
     element.textTracks[0].oncuechange(event);


### PR DESCRIPTION
Rewrote most of the closed captions implementation from scratch. The main issues that were addressed by these changes are the following:

- Allowing captions to be switched via the native fullscreen UI on iOS
- Allowing captions to be turned off via the native fullscreen UI on iOS
- Keeping the player's UI in sync with the native fullscreen UI on iOS

These changes will also fix the following:

- In-manifest/In-stream captions for VOD will now be available on supported platforms
- Metadata text tracks will no longer show up in the UI
- Text tracks will no longer be removed and re-added on each call to `setClosedCaptions`
- VTT files will no longer be requested on each call to `setClosedCaptions` and when pausing and then resuming
- More robust handling of multi closed captions for live

**Note:** I will create a separate PR for new unit tests, for now I only fixed the existing ones.