### PR TITLE
[PLAYER-4264] Fix for continuous playback on mobile browsers

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -46,7 +46,7 @@ import CONSTANTS from "./constants/constants";
         if (!!videoElement.canPlayType("audio/ogg")) {
           list.push(OO.VIDEO.ENCODING.OGG);
         }
-        
+
         if (!!videoElement.canPlayType("audio/x-m4a")) {
           list.push(OO.VIDEO.ENCODING.M4A);
         }
@@ -73,7 +73,7 @@ import CONSTANTS from "./constants/constants";
           list.push(OO.VIDEO.ENCODING.AKAMAI_HD2_VOD_HLS);
           list.push(OO.VIDEO.ENCODING.AKAMAI_HD2_HLS);
           list.push(OO.VIDEO.ENCODING.AUDIO_HLS);
-          
+
         }
       }
       return list;
@@ -1384,7 +1384,10 @@ import CONSTANTS from "./constants/constants";
      */
     var raiseEndedEvent = _.bind(function(event) {
       stopUnderflowWatcher();
-      if (!_video.ended && OO.isSafari) {
+      if (
+        !_currentUrl || // iOS Safari will trigger an ended event when the source is cleared with an empty string
+        (!_video.ended && OO.isSafari)
+      ) {
         // iOS raises ended events sometimes when a new stream is played in the same video element
         // Prevent this faulty event from making it to the player message bus
         return;

--- a/tests/unit/main_html5/wrapper-event-tests.js
+++ b/tests/unit/main_html5/wrapper-event-tests.js
@@ -772,6 +772,7 @@ describe('main_html5 wrapper tests', function () {
   });
 
   it('should only raise ended event once per stream', function(){
+    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS);
     $(element).triggerHandler("ended");
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.ENDED]);
     vtc.notifyParameters = null;
@@ -783,6 +784,7 @@ describe('main_html5 wrapper tests', function () {
   });
 
   it('should unblock raising of ended event after a new stream begins loading', function(){
+    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS);
     $(element).triggerHandler("ended");
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.ENDED]);
     vtc.notifyParameters = null;
@@ -791,6 +793,16 @@ describe('main_html5 wrapper tests', function () {
     $(element).triggerHandler("loadstart");
     $(element).triggerHandler("ended");
     expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.ENDED]);
+  });
+
+  it('should not raise ended event when video source is cleared', function(){
+    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS);
+    $(element).triggerHandler("ended");
+    expect(vtc.notifyParameters).to.eql([vtc.interface.EVENTS.ENDED]);
+    vtc.notifyParameters = null;
+    wrapper.setVideoUrl("", OO.VIDEO.ENCODING.HLS);
+    $(element).triggerHandler("ended");
+    expect(vtc.notifyParameters).to.be(null);
   });
 
   // TODO: When we have platform testing support, test for iOS behavior for ended event raised when ended != true
@@ -1042,6 +1054,7 @@ describe('main_html5 wrapper tests', function () {
   });
 
   it('should raise timeUpdate on replay if initial time is more than video duration', function(){
+    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS);
     element.duration = 20;
     wrapper.setInitialTime(40);
     wrapper.play();
@@ -1325,6 +1338,7 @@ describe('main_html5 wrapper tests', function () {
     $(element).triggerHandler({ type: "webkitendfullscreen" });
     expect(vtc.notifyParameters).to.not.be(null);
     vtc.notifyParameters = null;
+    wrapper.setVideoUrl("url", OO.VIDEO.ENCODING.HLS);
     $(element).triggerHandler({ type: "play" });
     expect(vtc.notifyParameters).to.not.be(null);
     vtc.notifyParameters = null;


### PR DESCRIPTION
We have some code in the core which clears the current video stream by setting an empty source before a new source is loaded. On iOS Safari this was causing the `ended` event to be triggered when the source was cleared, which in turn caused the player to display the end screen when a new video was loaded.