### PR TITLE
Removed the video pause call from primeVideoElement

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -736,8 +736,6 @@ import CONSTANTS from "./constants/constants";
             ignoreFirstPlayingEvent = false;
           });
         }
-      } else {
-        _video.pause();
       }
     };
 


### PR DESCRIPTION
This is a potential fix for the https://jira.corp.ooyala.com/browse/PBW-7648.
I have also tried to put this pause in `then` of `playPromise` and it just stops after start of the playing so it seems to me that it is pointless here.
Unit tests passed.