### PR TITLE
Player 5365 airplay icon bug with discovery and playlists

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "gulp",
     "test": "jest",
+    "test:debug": "node --inspect node_modules/.bin/jest --runInBand",
     "build:future": "webpack --mode development",
     "build-prod": "webpack --mode production",
     "start": "webpack-dev-server",

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -347,6 +347,7 @@ require('../../../html5-common/js/utils/environment.js');
             delete _video.src;
           } else if (OO.isMacOs && OO.isSafari) {
             _video.removeAttrribute('src');
+            // would not trigger Video#loadstart or Airplay#playbackTargetChanged events
             _video.load();
           } else {
             _video.src = null;

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -346,7 +346,7 @@ require('../../../html5-common/js/utils/environment.js');
           if (OO.isIos) {
             delete _video.src;
           } else if (OO.isMacOs && OO.isSafari) {
-            _video.removeAttrribute('src');
+            _video.removeAttribute('src');
             // would not trigger Video#loadstart or Airplay#playbackTargetChanged events
             _video.load();
           } else {

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -341,10 +341,13 @@ require('../../../html5-common/js/utils/environment.js');
         urlChanged = true;
         resetStreamData();
         if (_currentUrl === '') {
-          // Workaround of an issue where iOS attempts to set the src to <RELATIVE_PATH>/null
+          // Workaround of an issue where iOS and MacOS attempt to set the src to <RELATIVE_PATH>/null
           // when setting source to null
           if (OO.isIos) {
             delete _video.src;
+          } else if (OO.isMacOs && OO.isSafari) {
+            _video.removeAttrribute('src');
+            _video.load();
           } else {
             _video.src = null;
           }

--- a/tests/unit/main_html5/wrapper-api-tests.js
+++ b/tests/unit/main_html5/wrapper-api-tests.js
@@ -169,6 +169,16 @@ describe('main_html5 wrapper tests', function () {
     expect(typeof element.src).to.eql("undefined");
   });
 
+  it('should set src to empty string on MacOS Safari', () => {
+    OO.isMacOs = true;
+    OO.isSafari = true;
+    const spy = sinon.spy(element, 'removeAttribute');
+    wrapper.setVideoUrl('url');
+    expect(spy.callCount).to.be(0);
+    wrapper.setVideoUrl('');
+    expect(spy.calledOnceWith('src')).to.be(true);
+  });
+
   it('should call stream load', function(){
     var loadSpy = sinon.spy(element, "load");
     var pauseSpy = sinon.spy(element, "pause");


### PR DESCRIPTION
airplay icon is not displayed as expected with discovery and playlists
[Jira ticket](https://jira.corp.ooyala.com/browse/PLAYER-5365)

[Related Core PR](https://git.corp.ooyala.com/projects/PBW/repos/mjolnir/pull-requests/658/overview)

in Safari (for both MacOS and iOS) 
```javascript
video.src = null;
```
leads to (for example) video.**src** === 'debug.ooyala.com/ea/**null**'
This issue was resolved for iOS like that
```javascript
delete _video.src
```
Added similar workaround for MacOS since delete doesn't work here:
```jacascript
_video.removeAttrribute('src');
```
will set _video.src to ' ' (empty string) 
```javascript
_video.load()
```
to reset the video (video 'loadstart' and airplay 'playbackTargetChanged' events won't be fired that way)