### PR TITLE
[PBW-7937] fake _ended_ event for some mp4 assets in MS Edge now ignored

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -13,7 +13,6 @@ require('../../../html5-common/js/utils/InitModules/InitOOHazmat.js');
 require('../../../html5-common/js/utils/constants.js');
 require('../../../html5-common/js/utils/utils.js');
 require('../../../html5-common/js/utils/environment.js');
-
 (function(_, $) {
   let pluginName = 'ooyalaHtml5VideoTech';
   let currentInstances = {};
@@ -1394,15 +1393,15 @@ require('../../../html5-common/js/utils/environment.js');
      */
     const raiseEndedEvent = _.bind(function(event) {
       stopUnderflowWatcher();
-      if (
+      if (videoEnded || // no double firing ended event
         !_currentUrl || // iOS Safari will trigger an ended event when the source is cleared with an empty string
-        (!_video.ended && OO.isSafari)
-      ) {
-        // iOS raises ended events sometimes when a new stream is played in the same video element
+        (OO.isEdge && !event) || // Edge fires empty ended event in the beginning on some mp4
+        (!_video.ended && OO.isSafari) // iOS raises ended events sometimes when a new stream is played in the same video element
         // Prevent this faulty event from making it to the player message bus
+      ) {
         return;
       }
-      if (videoEnded) { return; } // no double firing ended event.
+
       videoEnded = true;
       initialTime.value = 0;
 
@@ -2164,6 +2163,7 @@ require('../../../html5-common/js/utils/environment.js');
       if (isM3u8) {
         let durationResolved = resolveDuration(event.target.duration);
         let durationInt = Math.floor(durationResolved);
+        console.log(_video.currentTime, durationResolved, durationInt);
         if ((_video.currentTime === durationResolved) && (durationResolved > durationInt)) {
           console.log('VTC_OO: manually triggering end of stream for m3u8',
             _currentUrl, durationResolved, _video.currentTime);

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -2163,7 +2163,6 @@ require('../../../html5-common/js/utils/environment.js');
       if (isM3u8) {
         let durationResolved = resolveDuration(event.target.duration);
         let durationInt = Math.floor(durationResolved);
-        console.log(_video.currentTime, durationResolved, durationInt);
         if ((_video.currentTime === durationResolved) && (durationResolved > durationInt)) {
           console.log('VTC_OO: manually triggering end of stream for m3u8',
             _currentUrl, durationResolved, _video.currentTime);


### PR DESCRIPTION
Discovered that MS Edge browser for the specific mp4 assets fires `ended` event with `undefined` data provided right in the beginning of the playback. Added this into the list of conditions to be ignored.