### PR TITLE
[PBW-8033] playsinline attribute now added in desktop as well

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -120,14 +120,10 @@ require('../../../html5-common/js/utils/environment.js');
         // http://developer.apple.com/library/safari/#documentation/AudioVideo/Conceptual/AirPlayGuide/OptingInorOutofAirPlay/OptingInorOutofAirPlay.html
         //
         video.attr('x-webkit-airplay', 'allow');
-
-        // enable inline playback for mobile
-        if (pluginParams['iosPlayMode'] === 'inline') {
-          const iosVersion = 10;
-          if (OO.iosMajorVersion >= iosVersion) {
-            video.attr('playsinline', '');
-          }
-        }
+      }
+      // enable inline playback for mobile
+      if (pluginParams['iosPlayMode'] === 'inline') {
+        video.attr('playsinline', '');
       }
 
       let element = new OoyalaVideoWrapper(domId, video[0], playerId);

--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -121,7 +121,7 @@ require('../../../html5-common/js/utils/environment.js');
         video.attr('x-webkit-airplay', 'allow');
       }
       // enable inline playback for mobile
-      if (pluginParams['iosPlayMode'] === 'inline') {
+      if (pluginParams && pluginParams['iosPlayMode'] === 'inline') {
         video.attr('playsinline', '');
       }
 


### PR DESCRIPTION
TS requested this attribute to be added on MacOS, not only IOS. Done.
To confirm checked that Bitmovin doing the same for desktop browsers.