### PR TITLE
[PBW-7936] Audio player not working on Android 9

### DIFF
--- a/src/main/js/main_html5.js
+++ b/src/main/js/main_html5.js
@@ -63,7 +63,10 @@ require('../../../html5-common/js/utils/environment.js');
           list.push(OO.VIDEO.ENCODING.HLS);
           list.push(OO.VIDEO.ENCODING.AKAMAI_HD2_VOD_HLS);
           list.push(OO.VIDEO.ENCODING.AKAMAI_HD2_HLS);
-          list.push(OO.VIDEO.ENCODING.AUDIO_HLS);
+          // [PBW-7936] We don't support audio_hls on Android Chrome
+          if (!OO.isChrome && !OO.isAndroid) {
+            list.push(OO.VIDEO.ENCODING.AUDIO_HLS);
+          }
         }
 
         // Sony OperaTV supports HLS but doesn't properly report it so we are forcing it here


### PR DESCRIPTION
The issue is that when customer accidentally or in purpose adds both main and bitmovin plugin to their implementation, main plugin will try to play audio_hls in cases where it shouldn't have like Android Chrome. This should only be played with Bitmovin plugin.

This fix consists in removing audio_hls supported encoding in Android Chrome. 